### PR TITLE
typescript-ify functions/ and add groups stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ scripts/config.json
 functions/config.json
 public/first-input-delay.min.js
 bks
+
+functions/dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.eslintrc.json

--- a/firebase.json
+++ b/firebase.json
@@ -5,7 +5,7 @@
   },
   "functions": {
     "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run lint"
+      "npm --prefix \"$RESOURCE_DIR\" run build"
     ]
   },
   "hosting": [

--- a/functions/.eslintrc.json
+++ b/functions/.eslintrc.json
@@ -1,122 +1,51 @@
 {
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    // Required for certain syntax usages
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   },
   "plugins": [
     "promise"
   ],
-  "extends": "eslint:recommended",
+  "extends": [
+    "plugin:@typescript-eslint/recommended"
+  ],
   "rules": {
-    // Removed rule "disallow the use of console" from recommended eslint rules
     "no-console": "off",
-
-    // Removed rule "disallow multiple spaces in regular expressions" from recommended eslint rules
     "no-regex-spaces": "off",
-
-    // Removed rule "disallow the use of debugger" from recommended eslint rules
     "no-debugger": "off",
-
-    // Removed rule "disallow unused variables" from recommended eslint rules
     "no-unused-vars": "off",
-
-    // Removed rule "disallow mixed spaces and tabs for indentation" from recommended eslint rules
     "no-mixed-spaces-and-tabs": "off",
-
-    // Removed rule "disallow the use of undeclared variables unless mentioned in /*global */ comments" from recommended eslint rules
     "no-undef": "off",
-
-    // Warn against template literal placeholder syntax in regular strings
     "no-template-curly-in-string": 1,
-
-    // Warn if return statements do not either always or never specify values
     "consistent-return": 1,
-
-    // Warn if no return statements in callbacks of array methods
     "array-callback-return": 1,
-
-    // Requre the use of === and !==
     "eqeqeq": 2,
-
-    // Disallow the use of alert, confirm, and prompt
     "no-alert": 2,
-
-    // Disallow the use of arguments.caller or arguments.callee
     "no-caller": 2,
-
-    // Disallow null comparisons without type-checking operators
     "no-eq-null": 2,
-
-    // Disallow the use of eval()
     "no-eval": 2,
-
-    // Warn against extending native types
     "no-extend-native": 1,
-
-    // Warn against unnecessary calls to .bind()
     "no-extra-bind": 1,
-
-    // Warn against unnecessary labels
     "no-extra-label": 1,
-
-    // Disallow leading or trailing decimal points in numeric literals
     "no-floating-decimal": 2,
-
-    // Warn against shorthand type conversions
     "no-implicit-coercion": 1,
-
-    // Warn against function declarations and expressions inside loop statements
     "no-loop-func": 1,
-
-    // Disallow new operators with the Function object
     "no-new-func": 2,
-
-    // Warn against new operators with the String, Number, and Boolean objects
     "no-new-wrappers": 1,
-
-    // Disallow throwing literals as exceptions
     "no-throw-literal": 2,
-
-    // Require using Error objects as Promise rejection reasons
     "prefer-promise-reject-errors": 2,
-
-    // Enforce “for” loop update clause moving the counter in the right direction
     "for-direction": 2,
-
-    // Enforce return statements in getters
     "getter-return": 2,
-
-    // Disallow await inside of loops
     "no-await-in-loop": 2,
-
-    // Disallow comparing against -0
     "no-compare-neg-zero": 2,
-
-    // Warn against catch clause parameters from shadowing variables in the outer scope
     "no-catch-shadow": 1,
-
-    // Disallow identifiers from shadowing restricted names
     "no-shadow-restricted-names": 2,
-
-    // Enforce return statements in callbacks of array methods
     "callback-return": 2,
-
-    // Require error handling in callbacks
     "handle-callback-err": 2,
-
-    // Warn against string concatenation with __dirname and __filename
     "no-path-concat": 1,
-
-    // Prefer using arrow functions for callbacks
     "prefer-arrow-callback": 1,
-
-    // Return inside each then() to create readable and reusable Promise chains.
     "promise/always-return": 2,
-
-    //Enforces the use of catch() on un-returned promises
     "promise/catch-or-return": 2,
-
-    // Warn against nested then() or catch() statements
     "promise/no-nesting": 1
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -91,6 +91,18 @@
         "through2": "^3.0.0"
       }
     },
+    "@google-cloud/functions-framework": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-1.5.1.tgz",
+      "integrity": "sha512-QvEB0WxP9P+/ykXVM2l41MhPvq0mDKIMoINHPi1Rm4CDuhFEShgOimNXKf/g0ROEyCKVFWO7IfWr4lrVH5CP0Q==",
+      "dev": true,
+      "requires": {
+        "body-parser": "^1.18.3",
+        "express": "^4.16.4",
+        "minimist": "^1.2.0",
+        "on-finished": "^2.3.0"
+      }
+    },
     "@google-cloud/paginator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.1.tgz",
@@ -257,21 +269,81 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-1.2.0.tgz",
       "integrity": "sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw=="
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "dev": true
+    },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/duplexify": {
@@ -282,24 +354,63 @@
         "@types/node": "*"
       }
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.10",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.10.tgz",
-      "integrity": "sha512-gM6evDj0OvTILTRKilh9T5dTaGpv1oYiFcJAfgSejuMJgGJUsD9hKEU2lB4aiTNy4WwChxRnjfYFuBQsULzsJw==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/gm": {
+      "version": "1.18.7",
+      "resolved": "https://registry.npmjs.org/@types/gm/-/gm-1.18.7.tgz",
+      "integrity": "sha512-7gOsCmtTqq3NSKinO2WsYA2uC2RVcW0wlPWXsMDP3rPNoV8Ba+8+OZhfkVstCjar2Yud0RM3jwAIv/h2cLTcSA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
+    "@types/json2csv": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json2csv/-/json2csv-5.0.0.tgz",
+      "integrity": "sha512-oGIln5Jzp8X8Tgu7rAzim3o68jsIGbE2Qd30jVvP4SxGasH+OBc+a/uwDS6Bh3D8LBLzl2ih4iYZfBRHdhPYpg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true,
+      "optional": true
     },
     "@types/lodash": {
       "version": "4.14.144",
@@ -317,10 +428,39 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
+    "@types/mkdirp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.0.tgz",
+      "integrity": "sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mkdirp-promise": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp-promise/-/mkdirp-promise-5.0.0.tgz",
+      "integrity": "sha512-rjHG/ZqgHWFHsnIOvkz7SVP8IaU/q1Kc/UtfkuJxjm0g9sIzwMCCdK3BUtaqwI4aH88bl4Ich4PbzTf4DSfRsA==",
+      "dev": true,
+      "requires": {
+        "@types/mkdirp": "*"
+      }
+    },
+    "@types/mocha": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
       "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
+    },
+    "@types/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
+      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -334,6 +474,144 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
+      }
+    },
+    "@types/sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+      "integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.31.0.tgz",
+      "integrity": "sha512-iIC0Pb8qDaoit+m80Ln/aaeu9zKQdOLF4SHcGLarSeY1gurW6aU4JsOPMjKQwXlw70MvWKZQc6S2NamA8SJ/gg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.31.0",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz",
+      "integrity": "sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.31.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.31.0.tgz",
+      "integrity": "sha512-uph+w6xUOlyV2DLSC6o+fBDzZ5i7+3/TxAsH4h3eC64tlga57oMb96vVlXoMwjR/nN+xyWlsnxtbDkB46M2EPQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.31.0",
+        "@typescript-eslint/typescript-estree": "2.31.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz",
+      "integrity": "sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "abort-controller": {
@@ -385,6 +663,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
@@ -408,6 +692,22 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -465,6 +765,12 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -507,6 +813,21 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -515,8 +836,13 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "optional": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "bun": {
       "version": "0.0.12",
@@ -564,6 +890,12 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -581,6 +913,22 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -595,6 +943,42 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -759,6 +1143,12 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
@@ -783,7 +1173,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "optional": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -805,6 +1194,12 @@
       "requires": {
         "streamsearch": "0.1.2"
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -872,6 +1267,47 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "optional": true
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      },
+      "dependencies": {
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -1184,6 +1620,15 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1211,6 +1656,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
       }
     },
     "firebase-admin": {
@@ -1285,6 +1739,15 @@
         "lodash": "^4.17.5"
       }
     },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1318,11 +1781,17 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "optional": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1363,6 +1832,12 @@
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
       }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.5",
@@ -1453,6 +1928,12 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "optional": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "gtoken": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
@@ -1468,7 +1949,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1477,6 +1957,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "hash-stream-validation": {
@@ -1499,6 +1985,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
@@ -1636,11 +2128,31 @@
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
       "optional": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "optional": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -1662,6 +2174,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-obj": {
       "version": "2.0.0",
@@ -1693,6 +2211,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1756,6 +2283,16 @@
         "lodash.get": "^4.4.2"
       }
     },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -1777,6 +2314,12 @@
         "ms": "^2.0.0",
         "xtend": "^4.0.1"
       }
+    },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
     },
     "jwa": {
       "version": "1.4.1",
@@ -1805,6 +2348,16 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -1872,6 +2425,15 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -1893,6 +2455,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1942,16 +2510,24 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "mkdirp-promise": {
@@ -1960,6 +2536,81 @@
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "requires": {
         "mkdirp": "*"
+      }
+    },
+    "mocha": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -1990,6 +2641,54 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -2000,10 +2699,22 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
       "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.1",
@@ -2014,8 +2725,29 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "optional": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2070,16 +2802,23 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-      "optional": true,
       "requires": {
         "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "optional": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -2095,6 +2834,12 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2107,10 +2852,22 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2264,6 +3021,15 @@
         }
       }
     },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -2278,6 +3044,27 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -2414,6 +3201,12 @@
         "send": "0.17.1"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -2439,6 +3232,38 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -2463,6 +3288,22 @@
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=",
       "optional": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -2505,6 +3346,48 @@
         "strip-ansi": "^5.2.0"
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2528,6 +3411,13 @@
       "requires": {
         "ansi-regex": "^4.1.0"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "optional": true
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -2629,15 +3519,154 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "ts-mocha": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-7.0.0.tgz",
+      "integrity": "sha512-7WfkQw1W6JZXG5m4E1w2e945uWzBoZqmnOHvpMu0v+zvyKLdUQeTtRMfcQsVEKsUnYL6nTyH4okRt2PZucmFXQ==",
+      "dev": true,
+      "requires": {
+        "ts-node": "7.0.1",
+        "tsconfig-paths": "^3.5.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+          "dev": true
+        }
+      }
+    },
+    "ts-node": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "ts-sinon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-sinon/-/ts-sinon-1.2.0.tgz",
+      "integrity": "sha512-71E4MkTIeTwd7aaCExKMtICDKpkIq+K6D8Qn/j5ZcwYaMI1w8VbKKBqh8jB5cBAyK72bTiUndzz2BtNF5fjk3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^11.15.10",
+        "@types/sinon": "^9.0.0",
+        "@types/sinon-chai": "^3.2.4",
+        "sinon": "^9.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.15.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.12.tgz",
+          "integrity": "sha512-iefeBfpmhoYaZfj+gJM5z9H9eiTwhuzhPsJgH/flx4HP2SBI2FNDra1D3vKljqPLGDr9Cazvh9gP9Xszc30ncA==",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tslint": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.2.tgz",
+      "integrity": "sha512-UyNrLdK3E0fQG/xWNqAFAC5ugtFyPO4JJR1KyyfQAyzR8W0fTRrC91A8Wej4BntFzcvETdCSDa/4PnNYJQLYiA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^4.0.1",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.3",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.10.0",
+        "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "type-check": {
       "version": "0.3.2",
@@ -2647,6 +3676,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",
@@ -2677,6 +3712,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",
@@ -2756,11 +3797,95 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -2799,10 +3924,86 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,12 +2,13 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "lint": "eslint .",
     "serve": "firebase serve --only functions",
+    "test": "ts-mocha -p tsconfig.json src/**/*.test.ts",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "build": "eslint . --ext ts && ./node_modules/.bin/tsc"
   },
   "dependencies": {
     "@google-cloud/pubsub": "^1.1.5",
@@ -22,12 +23,28 @@
     "mkdirp-promise": "^5.0.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.6",
+    "@types/express": "^4.17.6",
+    "@types/gm": "^1.18.7",
+    "@types/json2csv": "^5.0.0",
+    "@types/mkdirp-promise": "^5.0.0",
+    "@types/mocha": "^7.0.2",
+    "@typescript-eslint/eslint-plugin": "^2.31.0",
+    "@typescript-eslint/parser": "^2.31.0",
     "eslint": "^6.6.0",
     "eslint-plugin-promise": "^4.2.1",
-    "firebase-functions-test": "^0.1.6"
+    "firebase-functions-test": "^0.1.6",
+    "mocha": "^7.1.2",
+    "ts-mocha": "^7.0.0",
+    "ts-node": "^8.10.1",
+    "ts-sinon": "^1.2.0",
+    "tslint": "^6.1.2",
+    "typescript": "^3.8.3"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
-  "private": true
+  "eslintIgnore": ["*.test.ts"],
+  "private": true,
+  "main": "dist/index.js"
 }

--- a/functions/src/config.json
+++ b/functions/src/config.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "metadataServerUrl": "https://md.plasticpatrol.co.uk",
+    "serverUrl": "https://app.plasticpatrol.co.uk",
+    "twSite": "@Plastic_Patrol",
+    "twCreator": "@LizzieOutside",
+    "twDomain": "www.plasticpatrol.co.uk",
+    "_twDescriptionField": "pieces",
+    "twDescription": "The global movement that is crowdsource cleaning the planet. Download the Plastic Patrol app to join the movement!",
+    "twTitle": "Plastic Patrol"
+  }
+}

--- a/functions/src/index.js
+++ b/functions/src/index.js
@@ -1,0 +1,405 @@
+// @ts-ignore
+"use strict";
+
+import _ from "lodash";
+import json2csv from "json2csv";
+import * as functions from "firebase-functions";
+import mkdirp from "mkdirp-promise";
+import admin from "firebase-admin";
+import corsModule from "cors";
+import { PubSub } from "@google-cloud/pubsub";
+import path from "path";
+import os from "os";
+import fs from "fs";
+import gmModule from "gm";
+import express from "express";
+
+import config from "./config.json";
+import { computeStats } from "./utils";
+
+const cors = corsModule({ origin: true });
+const gm = gmModule.subClass({ imageMagick: true });
+
+const THUMB_MAX_SIZE = 50;
+const THUMB_NAME = "thumbnail.jpg";
+
+const MAIN_MAX_SIZE = 1014;
+const MAIN_NAME = "1024.jpg";
+
+const TOPIC = "update-stats";
+const DB_CACHE_AGE_MS = 1000 * 60 * 60 * 24 * 1; // 1 day
+const WEB_CACHE_AGE_S = 1 * 60 * 60 * 24 * 1; // 1day
+
+// const DB_CACHE_AGE_MS = 0; // none
+// const WEB_CACHE_AGE_S =    0; // noce
+
+admin.initializeApp();
+const firestore = admin.firestore();
+const auth = admin.auth();
+const settings = { timestampsInSnapshots: true };
+firestore.settings(settings);
+
+const pubsub = new PubSub();
+const app = express();
+app.use(cors);
+
+async function resize(inFile, outFile, maxSize) {
+  return new Promise((resolve, reject) => {
+    gm(inFile)
+      .resize(maxSize, maxSize)
+      .write(outFile, err => {
+        if (err) reject(err);
+        else resolve();
+      });
+  });
+}
+
+/**
+ * It publish a message indicating to recalculate the stats if the data doesn't have the field "updated".
+ *
+ * @param doc "/sys/stats" doc coming from firebase
+ *
+ * @returns {Promise<boolean>}
+ */
+async function pubIfNecessary(doc) {
+  let recalculate = true;
+
+  try {
+    const updatedTimestamp = doc
+      .data()
+      .updated.toDate()
+      .getTime();
+    const age = new Date().getTime() - updatedTimestamp;
+    recalculate = age > DB_CACHE_AGE_MS;
+    console.info(`States is ${age / 1000 / 60 / 60} hours old`);
+  } catch (e) {
+    console.info("states is corrupted. It will be re calculated: ", e);
+  }
+
+  if (recalculate) {
+    console.info("Need to recreate stats");
+
+    try {
+      await pubsub.createTopic(TOPIC);
+    } catch (e) {
+      console.info(`topic already created: ${e}`);
+    }
+
+    const messageId = await pubsub
+      .topic(TOPIC)
+      .publish(Buffer.from("Recreate the stats"));
+    console.info(`Message ${messageId} published.`);
+  }
+
+  return true;
+}
+
+/**
+ * When an image is uploaded in the Storage bucket We generate a thumbnail automatically using
+ * ImageMagick.
+ * After the thumbnail has been generated and uploaded to Cloud Storage,
+ * we write the public URL to the Firebase Realtime Database.
+ */
+const generateThumbnail = functions.storage
+  .object()
+  .onFinalize(async object => {
+    // File and directory paths.
+    const filePath = object.name;
+    const contentType = object.contentType; // This is the image MIME type
+    const fileDir = path.dirname(filePath);
+    const fileName = path.basename(filePath);
+    const thumbFilePath = path.normalize(path.join(fileDir, `${THUMB_NAME}`));
+    const mainFilePath = path.normalize(path.join(fileDir, `${MAIN_NAME}`));
+    const tempLocalFile = path.join(os.tmpdir(), filePath);
+    const tempLocalDir = path.dirname(tempLocalFile);
+    const tempLocalThumbFile = path.join(os.tmpdir(), thumbFilePath);
+    const tempLocalMainFile = path.join(os.tmpdir(), mainFilePath);
+
+    // Exit if this is triggered on a file that is not an image.
+    if (!contentType.startsWith("image/")) {
+      return console.info("This is not an image.", filePath);
+    }
+
+    // Exit if the image is already a thumbnail.
+    if (fileName !== "original.jpg") {
+      return console.info(
+        `I won't create a thumbnail for ${filePath} as it is not called "original.jpg"`
+      );
+    }
+
+    // Cloud Storage files.
+    const bucket = admin.storage().bucket(object.bucket);
+    const file = bucket.file(filePath);
+
+    const metadata = {
+      contentType: contentType,
+      // To enable Client-side caching you can set the Cache-Control headers here. Uncomment below.
+      "Cache-Control": "public,max-age=3600"
+    };
+
+    // Create the temp directory where the storage file will be downloaded.
+    await mkdirp(tempLocalDir);
+    // Download file from bucket.
+    await file.download({ destination: tempLocalFile });
+    console.info("The file has been downloaded to", tempLocalFile);
+    // Generate a thumbnail using ImageMagick.
+    await resize(tempLocalFile, tempLocalThumbFile, THUMB_MAX_SIZE);
+    console.info("Thumbnail created at", tempLocalThumbFile);
+    await resize(tempLocalFile, tempLocalMainFile, MAIN_MAX_SIZE);
+    console.info("Main created at", tempLocalMainFile);
+
+    // Uploading the Thumbnail.
+    const uploadThumb = bucket
+      .upload(tempLocalThumbFile, {
+        destination: thumbFilePath,
+        metadata: metadata
+      })
+      .then(() => bucket.makePublic());
+    const uploadMain = bucket
+      .upload(tempLocalMainFile, {
+        destination: mainFilePath,
+        metadata: metadata
+      })
+      .then(() => bucket.makePublic());
+
+    await Promise.all([uploadMain, uploadThumb]);
+    console.info("Thumbnail uploaded to Storage at", thumbFilePath);
+    console.info("Main uploaded to Storage at", mainFilePath);
+
+    // Once the image has been uploaded delete the local files to free up disk space.
+    fs.unlinkSync(tempLocalFile);
+    fs.unlinkSync(tempLocalThumbFile);
+    fs.unlinkSync(tempLocalMainFile);
+
+    return console.info(`Photos are public now`);
+  });
+
+app.get("/stats", async (req, res) => {
+  if (req.method !== "GET") {
+    return res.status(403).send("Forbidden!");
+  }
+
+  res.set(
+    "Cache-Control",
+    `public, max-age=${WEB_CACHE_AGE_S}, s-maxage=${WEB_CACHE_AGE_S * 2}`
+  );
+
+  try {
+    const doc = await firestore
+      .collection("sys")
+      .doc("stats")
+      .get();
+    if (doc.exists) {
+      const data = doc.data();
+      data.updated = data.updated.toDate();
+      data.serverTime = new Date();
+      res.json(data);
+      await pubIfNecessary(doc);
+      console.info(data);
+      return true;
+    } else {
+      throw new Error("/sys/stats doesn't exist");
+    }
+  } catch (e) {
+    console.info(e);
+    return res.status(503).send("stats not ready yet");
+  }
+});
+
+function convertFirebaseTimestampFieldsIntoDate(photo) {
+  const newPhoto = _.cloneDeep(photo);
+  _.forEach(newPhoto, (value, field) => {
+    if (value.constructor.name === "Timestamp") {
+      newPhoto[field] = value.toDate();
+    }
+  });
+  return newPhoto;
+}
+
+app.get("/photos.json", async (req, res) => {
+  if (req.method !== "GET") {
+    return res.status(403).send("Forbidden!");
+  }
+
+  res.set(
+    "Cache-Control",
+    `public, max-age=${WEB_CACHE_AGE_S}, s-maxage=${WEB_CACHE_AGE_S * 2}`
+  );
+
+  const querySnapshot = await firestore
+    .collection("photos")
+    .where("published", "==", true)
+    .get();
+  const data = {
+    photos: {},
+    serverTime: new Date()
+  };
+  querySnapshot.forEach(doc => {
+    // doc.data() is never undefined for query doc snapshots
+    data.photos[doc.id] = convertFirebaseTimestampFieldsIntoDate(doc.data());
+  });
+
+  res.json(data);
+  return true;
+});
+
+function plainToFlattenObject(object) {
+  const result = {};
+
+  function flatten(obj, prefix = "") {
+    _.forEach(obj, (value, key) => {
+      if (_.isObject(value)) {
+        flatten(value, `${prefix}${key}.`);
+      } else {
+        result[`${prefix}${key}`] = value;
+      }
+    });
+  }
+
+  flatten(JSON.parse(JSON.stringify(object)));
+
+  return result;
+}
+
+app.get("/photos.csv", async (req, res) => {
+  if (req.method !== "GET") {
+    return res.status(403).send("Forbidden!");
+  }
+
+  res.set(
+    "Cache-Control",
+    `public, max-age=${WEB_CACHE_AGE_S}, s-maxage=${WEB_CACHE_AGE_S * 2}`
+  );
+
+  const querySnapshot = await firestore
+    .collection("photos")
+    .where("published", "==", true)
+    .get();
+  const photos = [];
+  querySnapshot.forEach(doc => {
+    const photo = convertFirebaseTimestampFieldsIntoDate(doc.data());
+    const newPhoto = plainToFlattenObject(_.extend(photo, { id: doc.id }));
+
+    photos.push(newPhoto);
+  });
+
+  const parser = new json2csv.Parser();
+
+  let csv = "?";
+  try {
+    csv = parser.parse(photos);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(err);
+    return false;
+  }
+
+  res.setHeader("Content-Type", "text/csv");
+  res.setHeader(
+    "Content-Disposition",
+    'attachment; filename="' + "photos-" + Date.now() + '.csv"'
+  );
+  res.status(200).send(csv);
+  return true;
+});
+
+async function fetchUsers() {
+  // get all the users
+  let users = [];
+  let pageToken = undefined;
+  do {
+    /* eslint-disable no-await-in-loop */
+    const listUsersResult = await auth.listUsers(1000, pageToken);
+    pageToken = listUsersResult.pageToken;
+    if (listUsersResult.users) {
+      users = users.concat(listUsersResult.users);
+    }
+  } while (pageToken);
+  return users;
+}
+
+/**
+ * recalculate the stats and save them in the DB
+ *
+ * @type {CloudFunction<Message>}
+ */
+const updateStats = functions.pubsub.topic(TOPIC).onPublish(async () => {
+  const [rawUsers, groupDocuments, photos, users] = await Promise.all([
+    fetchUsers(),
+    firestore.collection("groups").get(),
+    firestore.collection("photos").get(),
+    firestore.collection("users").get()
+  ]);
+  const stats = await computeStats(rawUsers, groupDocuments, photos, users);
+  const statsWithTimestamp = {
+    updated: admin.firestore.FieldValue.serverTimestamp(),
+    ...stats
+  };
+  return await firestore
+    .collection("sys")
+    .doc("stats")
+    .set(statsWithTimestamp);
+});
+
+async function hostMetadata(req, res) {
+  const BUCKET = config.FIREBASE.storageBucket;
+  const SERVER_URL = config.metadata.serverUrl;
+  const TW_SITE = config.metadata.twSite;
+  const TW_CREATOR = config.metadata.twCreator;
+  const TW_DOMAIN = config.metadata.twDomain;
+
+  const paramsStr = req.url.substr(1);
+  const params = paramsStr.split("@");
+  const photoId = params[0];
+
+  let photo;
+  if (photoId.length > 0) {
+    photo = await firestore
+      .collection("photos")
+      .doc(photoId)
+      .get();
+  }
+
+  let indexHTML;
+  if (photo && photo.exists && photo.data().published) {
+    const TW_DESCRIPTION = config.metadata.twDescriptionField
+      ? photo.data()[config.metadata.twDescriptionField]
+      : config.metadata.twDescription;
+    const TW_TITLE = config.metadata.twTitle;
+    const TW_IMAGE = `https://storage.googleapis.com/${BUCKET}/photos/${photoId}/1024.jpg`;
+    const TW_IMAGE_ALT = TW_DESCRIPTION;
+
+    indexHTML = `
+      <html>
+        <meta http-equiv="refresh" content="0; URL='${SERVER_URL}/#/photos/${paramsStr}'" />
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="${TW_SITE}">
+        <meta name="twitter:title" content="${TW_TITLE}">
+        <meta name="twitter:description" content="${TW_DESCRIPTION}">
+        <meta name="twitter:creator" content="${TW_CREATOR}">
+        <meta name="twitter:image:src" content="${TW_IMAGE}">
+        <meta name="twitter:image:alt" content="${TW_IMAGE_ALT}" />
+        <meta name="twitter:domain" content="${TW_DOMAIN}">
+        <body> <!-- ${JSON.stringify(photo.data())} --> </body>
+      </html>
+    `;
+  } else {
+    indexHTML = `
+      <html>
+        <meta http-equiv="refresh" content="0; URL='${SERVER_URL}'" />
+        <body>
+            Nothing here
+         </body>
+      </html>
+    `;
+  }
+
+  res.status(200).send(indexHTML);
+}
+
+module.exports = {
+  api: functions.https.onRequest(app),
+  hostMetadata: functions.https.onRequest(hostMetadata),
+  generateThumbnail,
+  updateStats
+};

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,0 +1,49 @@
+export interface Photo {
+  owner_id: string;
+  moderated: boolean;
+  published: boolean;
+  pieces: number;
+}
+
+export interface Group {
+  displayName: string;
+}
+
+export interface RawUser {
+  uid: string;
+  displayName: string;
+}
+
+export interface User {
+  groups?: string[];
+}
+
+export interface GroupStats {
+  gid: string;
+  displayName: string;
+  pieces: number;
+  uploaded: number;
+}
+
+export interface UserStats {
+  uid: string;
+  displayName: string;
+  pieces: number;
+  uploaded: number;
+}
+
+export interface Stats {
+  totalUploaded: number;
+  moderated: number;
+  published: number;
+  rejected: number;
+  pieces: number;
+  users: UserStats[];
+  groups: GroupStats[];
+}
+
+export function notEmpty<TValue>(
+  value: TValue | null | undefined
+): value is TValue {
+  return value !== null && value !== undefined;
+}

--- a/functions/src/utils.test.ts
+++ b/functions/src/utils.test.ts
@@ -1,0 +1,121 @@
+import { it } from "mocha";
+import { strict as assert } from "assert";
+import { computeStats } from "./utils";
+import {
+  QuerySnapshot,
+  QueryDocumentSnapshot
+} from "@firebase/firestore-types";
+import { stubInterface } from "ts-sinon";
+import { User, Photo, Group, RawUser } from "./types";
+
+function makeQuerySnapshot<T>(id: string, data: T): QuerySnapshot<T> {
+  const snapshot = stubInterface<QuerySnapshot<T>>();
+  // @ts-ignore
+  snapshot.forEach = f => [{ id, data: () => data }].forEach(f);
+  return snapshot;
+}
+
+it("computesStats for users without groups", () => {
+  const userId = "123";
+  const groupId = "456";
+
+  const rawUser: RawUser = {
+    uid: userId,
+    displayName: "Bob"
+  };
+
+  const user: User = {};
+
+  const photo: Photo = {
+    owner_id: userId,
+    moderated: true,
+    published: true,
+    pieces: 10
+  };
+
+  const group: Group = {
+    displayName: "My Group"
+  };
+
+  const stats = computeStats(
+    [rawUser],
+    makeQuerySnapshot<Group>(groupId, group),
+    makeQuerySnapshot("photoId", photo),
+    makeQuerySnapshot(userId, user)
+  );
+  assert.deepEqual(stats.totalUploaded, 1);
+  assert.deepEqual(stats.moderated, 1);
+  assert.deepEqual(stats.rejected, 0);
+  assert.deepEqual(stats.published, 1);
+  assert.deepEqual(stats.pieces, 10);
+  assert.deepEqual(stats.users, [
+    {
+      uid: userId,
+      displayName: "Bob",
+      pieces: 10,
+      uploaded: 1
+    }
+  ]);
+  assert.deepEqual(stats.groups, [
+    {
+      gid: groupId,
+      displayName: "My Group",
+      pieces: 0,
+      uploaded: 0
+    }
+  ]);
+});
+
+it("computesStats with groups", () => {
+  const userId = "123";
+  const groupId = "456";
+
+  const rawUser: RawUser = {
+    uid: userId,
+    displayName: "Bob"
+  };
+
+  const user: User = {
+    groups: [groupId]
+  };
+
+  const photo: Photo = {
+    owner_id: userId,
+    moderated: true,
+    published: true,
+    pieces: 10
+  };
+
+  const group: Group = {
+    displayName: "My Group"
+  };
+
+  const stats = computeStats(
+    [rawUser],
+    makeQuerySnapshot<Group>(groupId, group),
+    makeQuerySnapshot("photoId", photo),
+    makeQuerySnapshot(userId, user)
+  );
+
+  assert.deepEqual(stats.totalUploaded, 1);
+  assert.deepEqual(stats.moderated, 1);
+  assert.deepEqual(stats.rejected, 0);
+  assert.deepEqual(stats.published, 1);
+  assert.deepEqual(stats.pieces, 10);
+  assert.deepEqual(stats.users, [
+    {
+      uid: userId,
+      displayName: "Bob",
+      pieces: 10,
+      uploaded: 1
+    }
+  ]);
+  assert.deepEqual(stats.groups, [
+    {
+      gid: groupId,
+      displayName: "My Group",
+      pieces: 10,
+      uploaded: 1
+    }
+  ]);
+});

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -1,0 +1,128 @@
+import _ from "lodash";
+import {
+  QuerySnapshot,
+  QueryDocumentSnapshot
+} from "@firebase/firestore-types";
+import {
+  RawUser,
+  Group,
+  User,
+  Photo,
+  Stats,
+  UserStats,
+  GroupStats,
+  notEmpty
+} from "./types";
+
+export const computeStats = (
+  rawUsers: RawUser[],
+  groupsSnapshot: QuerySnapshot<Group>,
+  photosSnapshot: QuerySnapshot<Photo>,
+  usersSnapshot: QuerySnapshot<User>
+): Stats => {
+  const stats: Stats = {
+    totalUploaded: 0,
+    moderated: 0,
+    published: 0,
+    rejected: 0,
+    pieces: 0,
+    users: [],
+    groups: []
+  };
+
+  const users: UserStats[] = rawUsers.map(user => {
+    const userShort = {
+      uid: user.uid,
+      displayName: user.displayName || "",
+      pieces: 0,
+      uploaded: 0
+    };
+    return userShort;
+  });
+
+  const groups: GroupStats[] = [];
+  groupsSnapshot.forEach((doc: QueryDocumentSnapshot<Group>) => {
+    const { displayName } = doc.data();
+    groups.push({
+      gid: doc.id,
+      displayName: displayName || "",
+      pieces: 0,
+      uploaded: 0
+    });
+  });
+
+  // map from user -> the list of groups they are in
+  const userToGroups: { [key: string]: GroupStats[] } = {};
+  usersSnapshot.forEach((doc: QueryDocumentSnapshot<User>) => {
+    // users can have a "groups" field with a list of group IDs.
+    const userGroups = doc.data().groups;
+    if (userGroups !== undefined) {
+      // if the user has "groups", then find the group stats object corresponding
+      // to that group and set the resulting list in userToGroups
+      userToGroups[doc.id] = userGroups
+        .map(groupId => groups.find(group => group.gid === groupId))
+        .filter(notEmpty);
+    }
+  });
+
+  // console.info(users);
+  // console.info(users.find(user => !user.uid));
+
+  photosSnapshot.forEach(doc => {
+    // console.info(users.find(user => !user.uid));
+
+    const data = doc.data();
+    // console.info(data);
+
+    stats.totalUploaded++;
+
+    // has the upload been reviewed by a moderator ?
+    if (data.moderated) {
+      stats.moderated++;
+
+      // has it been approved ?
+      if (data.published) {
+        stats.published++;
+
+        const pieces = Number(data.pieces);
+        if (pieces > 0) stats.pieces += pieces;
+        // console.info(data.owner_id);
+        // console.info(users.find(user => !user.uid));
+
+        const owner = users.find(user => user.uid === data.owner_id);
+
+        // for each group that the owner is a member of, add the
+        // # of pieces to that group's total count
+        if (owner && owner.uid in userToGroups) {
+          userToGroups[owner.uid].forEach(group => {
+            group.uploaded++;
+            group.pieces += pieces;
+          });
+        }
+
+        // console.info(owner);
+
+        if (owner) {
+          // console.info("found: ", owner);
+          if (pieces > 0) owner.pieces += pieces;
+          owner.uploaded++;
+          owner.displayName = owner.displayName || "";
+
+          // console.info(owner);
+        } else {
+          // console.info(`No user with id = '${data.owner_id}'`);
+        }
+      } else {
+        stats.rejected++;
+      }
+    }
+  });
+
+  stats.users = users.map(user => {
+    // delete user.uid;
+    return user;
+  });
+
+  stats.groups = groups;
+  return stats;
+};

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "target": "es6",
+    "allowJs": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": "src"
+  },
+  "include": ["./src/"]
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "coveralls": "^3.0.7",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
-    "firebase-admin": "^8.7.0",
+    "firebase-admin": "^8.12.1",
     "firebase-tools": "^7.8.0",
     "first-input-delay": "^0.1.3",
     "http-server": "^0.11.1",

--- a/src/components/DrawerContainer.tsx
+++ b/src/components/DrawerContainer.tsx
@@ -82,7 +82,8 @@ export default function DrawerContainer({
   const listItemsTopUnderBreak: Page[] = [
     PAGES.feedbackReports,
     PAGES.leaderboard,
-    PAGES.cleanUps
+    PAGES.cleanUps,
+    PAGES.groups
   ];
   const listItemsBottom: Page[] = [
     PAGES.tutorial,

--- a/src/components/DrawerContainer.tsx
+++ b/src/components/DrawerContainer.tsx
@@ -82,9 +82,8 @@ export default function DrawerContainer({
   const listItemsTopUnderBreak: Page[] = [
     PAGES.feedbackReports,
     PAGES.leaderboard,
-    PAGES.cleanUps,
-    PAGES.groups
-  ];
+    PAGES.cleanUps
+  ].concat(config.ENABLE_GROUPS ? [PAGES.groups] : []);
   const listItemsBottom: Page[] = [
     PAGES.tutorial,
     PAGES.about,

--- a/src/components/Groups/GroupAdd.js
+++ b/src/components/Groups/GroupAdd.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { withStyles } from "@material-ui/core/styles";
+
+import PageWrapper from "../PageWrapper";
+import Typography from "@material-ui/core/Typography";
+
+const styles = theme => ({
+  message: {
+    color: theme.palette.common.black,
+    padding: theme.spacing(1.5),
+    fontSize: "inherit"
+  }
+});
+
+class GroupAdd extends React.Component {
+  render() {
+    const { classes, label, handleClose } = this.props;
+    return (
+      <PageWrapper label={label} handleClose={handleClose} hasLogo={false}>
+        <Typography variant="h1" color="inherit" className={classes.message}>
+          feature coming soon!
+        </Typography>
+      </PageWrapper>
+    );
+  }
+}
+
+export default withStyles(styles)(GroupAdd);

--- a/src/components/Groups/GroupList.js
+++ b/src/components/Groups/GroupList.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { withStyles } from "@material-ui/core/styles";
+
+import PageWrapper from "../PageWrapper";
+import Typography from "@material-ui/core/Typography";
+
+const styles = theme => ({
+  message: {
+    color: theme.palette.common.black,
+    padding: theme.spacing(1.5),
+    fontSize: "inherit"
+  }
+});
+
+class GroupList extends React.Component {
+  render() {
+    const { handleClose, classes, label, groupsArray, config } = this.props;
+    groupsArray.sort(
+      (a, b) => b[config.GROUPS_FIELD.name] - a[config.GROUPS_FIELD.name]
+    );
+    console.log("groups array:", groupsArray);
+
+    return (
+      <PageWrapper label={label} handleClose={handleClose} hasLogo={false}>
+        <Typography variant="h1" color="inherit" className={classes.message}>
+          your groups here - coming soon!
+        </Typography>
+      </PageWrapper>
+    );
+  }
+}
+
+export default withStyles(styles)(GroupList);

--- a/src/components/Groups/GroupMain.js
+++ b/src/components/Groups/GroupMain.js
@@ -1,0 +1,93 @@
+import React from "react";
+
+import { withStyles } from "@material-ui/core/styles";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import GroupIcon from "@material-ui/icons/Group";
+import GroupAddIcon from "@material-ui/icons/GroupAdd";
+
+import PageWrapper from "../../components/PageWrapper";
+// import config from '../../custom/config';
+
+const styles = theme => ({
+  content: {
+    height: "100%",
+    overflow: "auto",
+    "-webkit-overflow-scrolling": "touch",
+    marginTop: theme.spacing(1.5),
+    marginBottom: theme.spacing(0.5),
+    marginLeft: theme.spacing(0.5),
+    marginRight: theme.spacing(0.5),
+    alignItems: "center"
+  },
+  root: {
+    flexGrow: 1
+  },
+  icon: {
+    fontSize: 60,
+    margin: theme.spacing(0.5),
+    alignItems: "center"
+  },
+  labeltext: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    margin: theme.spacing(0.5)
+  }
+});
+
+class Groups extends React.Component {
+  groupListLink = () => {
+    this.props.history.push(this.props.config.PAGES.grouplist.path);
+  };
+
+  groupAddLink = () => {
+    this.props.history.push(this.props.config.PAGES.groupadd.path);
+  };
+
+  render() {
+    const { handleClose, label, classes } = this.props;
+
+    return (
+      <PageWrapper label={label} handleClose={handleClose} hasLogo={true}>
+        <div>
+          <Grid container spacing={3}>
+            <Grid item xs={3}></Grid>
+
+            <Grid item xs={6}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={this.groupListLink}
+              >
+                list my groups
+                <GroupIcon className={classes.icon}>list groups</GroupIcon>
+              </Button>
+            </Grid>
+
+            <Grid item xs={3}></Grid>
+
+            <Grid item xs={3}></Grid>
+
+            <Grid item xs={6}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={this.groupAddLink}
+              >
+                add a group
+                <GroupAddIcon className={classes.icon}>
+                  add a group
+                </GroupAddIcon>
+              </Button>
+            </Grid>
+
+            <Grid item xs={3}></Grid>
+          </Grid>
+        </div>
+      </PageWrapper>
+    );
+  }
+}
+
+export default withStyles(styles)(Groups);

--- a/src/custom/config.tsx
+++ b/src/custom/config.tsx
@@ -3,6 +3,7 @@ import _ from "lodash";
 
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import GroupIcon from "@material-ui/icons/Group";
 import SchoolIcon from "@material-ui/icons/School";
 import DashboardIcon from "@material-ui/icons/Dashboard";
 import HelpIcon from "@material-ui/icons/Help";
@@ -30,82 +31,98 @@ const secondaryContrastText = styles.primaryContrastText;
 const PAGES: { [pageName: string]: Page } = {
   map: {
     path: "/",
-    label: "Map",
+    label: "Map"
   },
   embeddable: {
     path: "/embeddable",
-    label: "Map",
+    label: "Map"
   },
   photos: {
     path: "/photo",
-    label: "Photo",
+    label: "Photo"
   },
   moderator: {
     path: "/moderator",
     label: "Photo Approval",
     icon: <CheckCircleIcon />,
     visible: (user: User | undefined, online: boolean) =>
-      !!(user && user.isModerator),
+      !!(user && user.isModerator)
   },
   account: {
     path: "/account",
     label: "Account",
     icon: <AccountCircleIcon />,
-    visible: (user: User | undefined, online: boolean) => !!user,
+    visible: (user: User | undefined, online: boolean) => !!user
   },
   about: {
     path: "/about",
     label: "About",
     visible: (user: User | undefined, online: boolean) => true,
-    icon: <HelpIcon />,
+    icon: <HelpIcon />
   },
   tutorial: {
     path: "/tutorial",
     label: "Tutorial",
     visible: (user: User | undefined, online: boolean) => true,
-    icon: <SchoolIcon />,
+    icon: <SchoolIcon />
   },
   writeFeedback: {
     path: "/write-feedback",
     label: "Feedback",
     visible: (user: User | undefined, online: boolean) => true,
-    icon: <FeedbackIcon />,
+    icon: <FeedbackIcon />
   },
   events: {
     path: "/events",
-    label: "Clean-ups",
+    label: "Clean-ups"
   },
   partners: {
     path: "/partners",
-    label: "Partners",
+    label: "Partners"
   },
   leaderboard: {
     path: "/leaderboard",
     label: "Leaderboard",
     visible: (user: User | undefined, online: boolean) => true,
-    icon: <DashboardIcon />,
+    icon: <DashboardIcon />
   },
   feedbackReports: {
     path: "/feedback-reports",
     label: "Feedback Reports",
     icon: <LibraryBooksIcon />,
     visible: (user: User | undefined, online: boolean) =>
-      !!(user && user.isModerator),
+      !!(user && user.isModerator)
   },
   feedbackDetails: {
     path: "/feedback-details",
-    label: "Feedback Details",
+    label: "Feedback Details"
   },
   displayPhoto: {
     path: "/photos",
-    label: "photos",
+    label: "photos"
   },
   cleanUps: {
     path: "https://plasticpatrol.co.uk/clean-ups/",
     visible: (user: User | undefined, online: boolean) => true,
     icon: <EventIcon />,
-    label: "Clean-ups",
+    label: "Clean-ups"
   },
+  groups: {
+    path: "/groups",
+    label: "Groups",
+    visible: (user, online) => true,
+    icon: <GroupIcon />
+  },
+  grouplist: {
+    path: "/grouplist",
+    label: "List Groups",
+    visible: (user, online) => true
+  },
+  groupadd: {
+    path: "/groupadd",
+    label: "Create a Group",
+    visible: (user, online) => true
+  }
 };
 
 export default {
@@ -118,15 +135,15 @@ export default {
     _twDescriptionField: "pieces",
     twDescription:
       "The global movement that is crowdsource cleaning the planet. Download the Plastic Patrol app to join the movement!",
-    twTitle: "Plastic Patrol",
+    twTitle: "Plastic Patrol"
   },
   MAX_IMAGE_SIZE: 2048,
   THEME: {
     palette: {
       primary: { main: primaryMain, contrastText: primaryContrastText },
-      secondary: { main: secondaryMain, contrastText: secondaryContrastText },
+      secondary: { main: secondaryMain, contrastText: secondaryContrastText }
     },
-    spacing: 10,
+    spacing: 10
   },
   MAP_SOURCE: "mapbox://styles/mapbox/streets-v10",
   // MAP_SOURCE: "https://s3-eu-west-1.amazonaws.com/tiles.os.uk/styles/open-zoomstack-outdoor/style.json",
@@ -137,7 +154,7 @@ export default {
   GA_PROPERTY_ID: "189010506",
   PHOTO_ZOOMED_FIELDS: {
     updated: (s: string) => new Date(s).toDateString(),
-    pieces: (s: string) => s,
+    pieces: (s: string) => s
   },
   ZOOM: 5,
   ZOOM_FLYTO: 15,
@@ -150,7 +167,7 @@ export default {
       placeholder: "eg. 123",
       inputProps: { min: 0, step: 1 },
       regexValidation: "^[0-9]+",
-      component: TitleTextField,
+      component: TitleTextField
     },
     categories: {
       component: MultiFields.MultiFieldsWithStyles,
@@ -177,7 +194,7 @@ export default {
           title: "Number",
           type: enums.TYPES.number,
           placeholder: "eg. 123",
-          regexValidation: "^[0-9]+",
+          regexValidation: "^[0-9]+"
         },
         brand: {
           component: TitleTextField,
@@ -185,20 +202,20 @@ export default {
           title: "Brand",
           type: enums.TYPES.string,
           placeholder: "eg. whatever",
-          regexValidation: ".+",
-        },
-      },
-    },
+          regexValidation: ".+"
+        }
+      }
+    }
   },
   PAGES,
   getStats: (photos: any, dbStats: Stats) => (dbStats && dbStats.pieces) || 0,
   ENABLE_GRAVATAR_PROFILES: true, //To update user-profile from Gravatar, value: true or false.
   SECURITY: {
-    UPLOAD_REQUIRES_LOGIN: true,
+    UPLOAD_REQUIRES_LOGIN: true
   },
   MODERATING_PHOTOS: 15,
   LEADERBOARD_FIELD: {
     label: "Pieces",
-    field: "pieces",
-  },
+    field: "pieces"
+  }
 };

--- a/src/custom/config.tsx
+++ b/src/custom/config.tsx
@@ -210,6 +210,7 @@ export default {
   PAGES,
   getStats: (photos: any, dbStats: Stats) => (dbStats && dbStats.pieces) || 0,
   ENABLE_GRAVATAR_PROFILES: true, //To update user-profile from Gravatar, value: true or false.
+  ENABLE_GROUPS: false,
   SECURITY: {
     UPLOAD_REQUIRES_LOGIN: true
   },

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -5,6 +5,9 @@ import config from "custom/config";
 
 import User from "types/User";
 
+import Groups from "components/Groups/GroupMain";
+import GroupList from "components/Groups/GroupList";
+import GroupAdd from "components/Groups/GroupAdd";
 import TutorialPage from "components/pages/TutorialPage";
 import PhotoPage from "components/pages/PhotoPage";
 import ProfilePage from "components/ProfilePage";
@@ -86,6 +89,43 @@ export function Routes({
           user={user}
         />
       </Route>
+
+      <Route
+        path={config.PAGES.groups.path}
+        render={props => (
+          <Groups
+            {...props}
+            config={config}
+            label={config.PAGES.groups.label}
+            handleClose={history.goBack}
+          />
+        )}
+      />
+
+      <Route
+        path={config.PAGES.grouplist.path}
+        render={props => (
+          <GroupList
+            {...props}
+            config={config}
+            label={config.PAGES.grouplist.label}
+            groupsArray={["group1", "group2"]}
+            handleClose={history.goBack}
+          />
+        )}
+      />
+
+      <Route
+        path={config.PAGES.groupadd.path}
+        render={props => (
+          <GroupAdd
+            {...props}
+            config={config}
+            label={config.PAGES.groupadd.label}
+            handleClose={history.goBack}
+          />
+        )}
+      />
 
       <ModeratorRoute path={config.PAGES.moderator.path} user={user}>
         <ModeratorPage

--- a/yarn.lock
+++ b/yarn.lock
@@ -6874,9 +6874,9 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-firebase-admin@^8.7.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.11.0.tgz#6292474c1270731655bc7c54a16499d54012fd0b"
+firebase-admin@^8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.12.1.tgz#a380c43a9e6ba37dfbe42211a253dd890a442063"
   dependencies:
     "@firebase/database" "^0.6.0"
     "@types/node" "^8.10.59"


### PR DESCRIPTION
* converts functions environment to be typescript compatible
* splits out logic for stats calculations into a typed utils.ts module
* adds a test for computeStats
* updates computeStats to include group tracking (for users that have groups, will just sum up those users contributions)
* adds GroupList/GroupAdd/Groups components, but these are unused (behind a feature flag). If you navigate to /groups manually, you can see them. But that's probably fine

Tested by deploying these functions to plastic-patrol-dev and then curling the endpoint to kick off a stats computation:

```
$ firebase deploy --only functions
$ curl https://us-central1-plastic-patrol-dev-722eb.cloudfunctions.net/api/stat
{
  "updated": "2020-05-09T14:11:24.325Z",
  "totalUploaded": 2,
  "published": 0,
  "users": [
    {
      "displayName": "Neil Fulwiler",
      "uploaded": 0,
      "pieces": 0,
      "uid": "CsoIvppvWrhY1jJqA34ImM9GZuh1"
    },
    {
      "displayName": "Tom Munro",
      "uploaded": 0,
      "pieces": 0,
      "uid": "hdGhwGHvtOUX7xrZsK1sPi0fXF13"
    }
  ],
  "groups": [],
  "rejected": 1,
  "pieces": 0,
  "moderated": 1,
  "serverTime": "2020-05-09T14:27:44.364Z"
}
```