### PR TITLE
pass through fromCamera, correct paths for cordova image handoff:

### DIFF
--- a/src/LocationProvider.tsx
+++ b/src/LocationProvider.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useContext, useEffect } from "react";
+import { GPSLocation } from "types/GPSLocation";
+
+const LocationContext = React.createContext<GPSLocation | undefined>(undefined);
+
+const LocationProvider: React.FC<{}> = ({ children }) => {
+  const [location, setLocation] = useState<GPSLocation | undefined>();
+
+  useEffect(() => {
+    if (!navigator || !navigator.geolocation) {
+      return;
+    }
+    const subscription = navigator.geolocation.watchPosition(
+      (position) => {
+        setLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+          online: true,
+          updated: new Date(position.timestamp) // it indicate the freshness of the location.
+        });
+      },
+      (error) => {
+        console.log("Error: ", error.message);
+        if (location) {
+          setLocation({
+            ...location,
+            online: false
+          });
+        }
+      }
+    );
+    return () => navigator.geolocation.clearWatch(subscription);
+  }, []);
+
+  return (
+    <LocationContext.Provider value={location}>
+      {children}
+    </LocationContext.Provider>
+  );
+};
+
+export const useGPSLocation = () => useContext(LocationContext);
+
+export default LocationProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import * as serviceWorker from "./serviceWorker";
 import config from "./custom/config";
 import { isIphoneAndCordova } from "./utils";
 import { gtagInit } from "./gtag.js";
+import LocationProvider from "./LocationProvider";
 
 serviceWorker.register();
 
@@ -31,12 +32,14 @@ if (
   process.env.NODE_ENV !== "development" &&
   localStorage.getItem("debug") !== "true"
 ) {
-  console.log = console.info = console.trace = console.warn = console.error = console.debug = _ => {};
+  console.log = console.info = console.trace = console.warn = console.error = console.debug = (
+    _
+  ) => {};
 }
 // it must set to fals (not enough to be absent)
 const devDissableDebugLog = localStorage.getItem("debug") === "false";
 if (devDissableDebugLog) {
-  console.debug = _ => {};
+  console.debug = (_) => {};
 }
 
 const theme = createMuiTheme(config.THEME);
@@ -50,7 +53,9 @@ const Wrapper = () => {
         handleClose={() => {}}
         onSignIn={() => setHandledPendingRedirect(true)}
       />
-      <App fields={Object.values(config.PHOTO_FIELDS)} config={config} />
+      <LocationProvider>
+        <App fields={Object.values(config.PHOTO_FIELDS)} config={config} />
+      </LocationProvider>
     </>
   );
 };

--- a/src/pages/dialogs/UploadSuccess/UploadSuccess.tsx
+++ b/src/pages/dialogs/UploadSuccess/UploadSuccess.tsx
@@ -42,7 +42,7 @@ export default function UploadSuccessDialog({
   return (
     <Dialog open PaperProps={{ className: styles.dialog }}>
       <p>
-        <div style={{ fontWeight: "bold" }}>Thank you.</div>
+        <p style={{ fontWeight: "bold" }}>Thank you.</p>
         <br />
         Your upload is now being moderated and will appear on the global map
         within 48 hours.

--- a/src/pages/photo/components/AddPhotoDialog/AddPhotoDialog.stories.tsx
+++ b/src/pages/photo/components/AddPhotoDialog/AddPhotoDialog.stories.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import React from "react";
+
+import AddPhotoDialog from "./AddPhotoDialog";
+
+export default { title: "AddPhotoDialog", component: AddPhotoDialog };
+
+export const addPhotoDialog = () => (
+  <AddPhotoDialog onClose={() => {}} handlePhotoSelect={() => {}} />
+);

--- a/src/pages/photo/components/AddPhotoDialog/AddPhotoDialog.tsx
+++ b/src/pages/photo/components/AddPhotoDialog/AddPhotoDialog.tsx
@@ -11,11 +11,11 @@ import Dialog from "@material-ui/core/Dialog";
 import CameraIcon from "@material-ui/icons/PhotoCamera";
 import PhotoLibraryIcon from "@material-ui/icons/PhotoLibrary";
 import CancelIcon from "@material-ui/icons/Close";
-import { useLocation } from "react-router-dom";
+import { CordovaCameraImage } from "types/Photo";
 
 type Props = {
   onClose: () => void;
-  handlePhotoSelect: (value: string | File) => void;
+  handlePhotoSelect: (image: CordovaCameraImage, fromCamera: boolean) => void;
 };
 
 export default function AddPhotoDialog({ onClose, handlePhotoSelect }: Props) {
@@ -24,9 +24,11 @@ export default function AddPhotoDialog({ onClose, handlePhotoSelect }: Props) {
       <List>
         <ListItem
           button
-          onClick={() =>
-            handlePhotoDialogItemClick("CAMERA", handlePhotoSelect)
-          }
+          onClick={() => {
+            handlePhotoDialogItemClick("CAMERA", (file) =>
+              handlePhotoSelect(file, true)
+            );
+          }}
         >
           <IconButton color="primary" edge={false}>
             <CameraIcon />
@@ -36,7 +38,9 @@ export default function AddPhotoDialog({ onClose, handlePhotoSelect }: Props) {
         <ListItem
           button
           onClick={() =>
-            handlePhotoDialogItemClick("PHOTOLIBRARY", handlePhotoSelect)
+            handlePhotoDialogItemClick("PHOTOLIBRARY", (file) =>
+              handlePhotoSelect(file, false)
+            )
           }
         >
           <IconButton color="primary" edge={false}>
@@ -57,7 +61,7 @@ export default function AddPhotoDialog({ onClose, handlePhotoSelect }: Props) {
 
 function handlePhotoDialogItemClick(
   value: string,
-  callback: (metaData: any, fileName: string) => void
+  callback: (file: CordovaCameraImage) => void
 ) {
   // @ts-ignore
   const Camera = navigator.camera;
@@ -73,8 +77,7 @@ function handlePhotoDialogItemClick(
     //https://cordova.apache.org/docs/en/1.6.0/cordova/camera/camera.getPicture.html
     (imageUri: string) => {
       const file = JSON.parse(imageUri);
-      const cordovaMetadata = JSON.parse(file.json_metadata);
-      callback(cordovaMetadata, file);
+      callback(file as CordovaCameraImage);
     },
     (message: string) => {
       console.log("Failed because: ", message);

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -165,18 +165,6 @@ export function Routes({
 
       <Route path={linkToPhotoPage()}>
         <PhotoRoute />
-        {/* <PhotoPage
-          //@ts-ignore - this exists
-          label={config.PAGES.photos.label}
-          file={file}
-          gpsLocation={gpsLocation}
-          online={online}
-          srcType={srcType}
-          cordovaMetadata={cordovaMetadata}
-          fields={fields}
-          handleClose={history.goBack}
-          handleRetakeClick={handleCameraClick}
-        /> */}
       </Route>
 
       <SignedInRoute path={config.PAGES.account.path} user={user}>

--- a/src/routes/photo/routes/categorise/links.ts
+++ b/src/routes/photo/routes/categorise/links.ts
@@ -1,26 +1,28 @@
 import { linkToPhotoPage } from "routes/photo/links";
 import { useLocation } from "react-router-dom";
+import {
+  FileState,
+  CordovaCameraImage,
+  isCordovaCameraImage
+} from "types/Photo";
 
 export function linkToCategorise(fileName: string = ":fileName") {
   return `${linkToPhotoPage()}/categorise/${fileName}`;
 }
 
-export function linkToCategoriseWithState(file: File | string) {
-  if (typeof file === "string") {
+export function linkToCategoriseWithState(
+  file: File | CordovaCameraImage,
+  fromCamera: boolean
+) {
+  if (isCordovaCameraImage(file)) {
     return {
       pathname: linkToCategorise("cordova"),
-      state: { encodedFile: file }
+      state: { cordovaImage: file, fromCamera }
     };
   }
 
-  const fileName = file.name;
-  return { pathname: linkToCategorise(fileName), state: { file } };
+  return { pathname: linkToCategorise(file.name), state: { file, fromCamera } };
 }
-
-export type FileState = {
-  file: File;
-  cordovaMetaData?: any;
-};
 
 export function getLocationFileState(location: any): FileState | undefined {
   if (!location.state) {
@@ -28,14 +30,17 @@ export function getLocationFileState(location: any): FileState | undefined {
     return;
   }
 
-  if (location.state.encodedFile) {
-    const file = JSON.parse(location.state.encodedFile);
-    const cordovaMetaData = JSON.parse(file.json_metadata);
-
-    return { file, cordovaMetaData };
+  if (location.state.cordovaImage) {
+    const image: CordovaCameraImage = location.state.cordovaImage;
+    const { filename, json_metadata } = image;
+    return {
+      filePath: filename as string,
+      cordovaMetadata: JSON.parse(json_metadata as string),
+      fromCamera: location.state.fromCamera as boolean
+    };
   }
 
-  return { file: location.state.file };
+  return { file: location.state.file, fromCamera: location.state.fromCamera };
 }
 
 export function useGetLocationFileState(): FileState | undefined {

--- a/src/routes/photo/routes/new/Route.tsx
+++ b/src/routes/photo/routes/new/Route.tsx
@@ -36,7 +36,13 @@ export default function NewPhotoRoute() {
         onChange={(e) => {
           const file = e.target && e.target.files && e.target.files[0];
           if (file) {
-            handlePhotoSelect(file, false);
+            // there's probably a more direct way to figure out if the image
+            // that we loaded is from the camera, but for now just check that
+            // the lastModified date is < 30s ago
+            const fileDate = file.lastModified;
+            const ageInMinutes = (new Date().getTime() - fileDate) / 1000 / 60;
+            const imgFromCamera = isNaN(ageInMinutes) || ageInMinutes < 0.5;
+            handlePhotoSelect(file, imgFromCamera);
           }
         }}
       />

--- a/src/routes/photo/routes/new/Route.tsx
+++ b/src/routes/photo/routes/new/Route.tsx
@@ -6,11 +6,14 @@ import AddPhotoDialog from "pages/photo/components/AddPhotoDialog";
 
 import { linkToAddDialog } from "./links";
 import { linkToCategoriseWithState } from "../categorise/links";
+import { CordovaCameraImage } from "types/Photo";
 
 export default function NewPhotoRoute() {
   const history = useHistory();
-  const handlePhotoSelect = (file: string | File) =>
-    history.push(linkToCategoriseWithState(file));
+  const handlePhotoSelect = (
+    file: File | CordovaCameraImage,
+    fromCamera: boolean
+  ) => history.push(linkToCategoriseWithState(file, fromCamera));
   const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
 
   // @ts-ignore
@@ -33,14 +36,16 @@ export default function NewPhotoRoute() {
         onChange={(e) => {
           const file = e.target && e.target.files && e.target.files[0];
           if (file) {
-            handlePhotoSelect(file);
+            handlePhotoSelect(file, false);
           }
         }}
       />
       <Route path={linkToAddDialog()} exact>
         <AddPhotoDialog
           onClose={() => history.goBack()}
-          handlePhotoSelect={handlePhotoSelect}
+          handlePhotoSelect={(image, fromCamera) =>
+            handlePhotoSelect(image, fromCamera)
+          }
         />
       </Route>
     </>

--- a/src/types/Photo.ts
+++ b/src/types/Photo.ts
@@ -10,11 +10,45 @@ type Photo = {
   pieces: number;
 };
 
+export type FilePath = string;
+
+export type CordovaImageMetadata = any;
+
 export type ImageMetadata = {
   imgSrc: any;
   imgExif: any;
-  imgLocation: LatLong | undefined;
+  imgLocation: LatLong | "not online" | "unable to extract from file";
   imgIptc: any;
 };
+
+export type CordovaFileState = {
+  filePath: FilePath;
+  cordovaMetadata: CordovaImageMetadata;
+  fromCamera: boolean;
+};
+
+export type BrowserFileState = {
+  file: File;
+  fromCamera: boolean;
+};
+
+export type FileState = CordovaFileState | BrowserFileState;
+
+export function isCordovaFileState(
+  fileState: FileState
+): fileState is CordovaFileState {
+  return (fileState as CordovaFileState).filePath !== undefined;
+}
+
+export type CordovaCameraImage = {
+  filename: string;
+  json_metadata: string;
+};
+
+export function isCordovaCameraImage(
+  file: File | CordovaCameraImage
+): file is CordovaCameraImage {
+  return (file as CordovaCameraImage).filename !== undefined;
+}
 
 export default Photo;


### PR DESCRIPTION
the way we were passing cordova image information through the location state wasn't exactly right, this types that up a bit and fixes it. Also fixes the throw Error() when we don't have location data, and raises a dialog that directs back to the "take photo" page. 

Adds in location data instead of {0, 0, offline} etc. 