### PR TITLE
💄 fix thank you screen styling on safari

### DIFF
--- a/src/pages/dialogs/UploadSuccess/UploadSuccess.tsx
+++ b/src/pages/dialogs/UploadSuccess/UploadSuccess.tsx
@@ -19,13 +19,11 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center"
   },
   button: {
-    width: "80%"
+    width: "80%",
+    minHeight: "min-content"
   },
   sponsoredBy: {
-    display: "flex",
-    flexDirection: "column",
     width: "100%",
-
     fontSize: "0.7rem",
     margin: 0,
     marginBottom: theme.spacing(0.5)


### PR DESCRIPTION
Safari:
<img width="254" alt="Screenshot 2020-06-02 at 20 45 04" src="https://user-images.githubusercontent.com/29929268/83562836-22334080-a512-11ea-9555-d486d7e23f13.png">

Chrome:
<img width="216" alt="Screenshot 2020-06-02 at 20 45 23" src="https://user-images.githubusercontent.com/29929268/83562841-23646d80-a512-11ea-942e-d2575d15474c.png">

Closes: #58 