### PR TITLE
💄 restyle leaderboard to account for users with rank >1000

### DIFF
--- a/src/components/Leaderboard/Leaderboard.tsx
+++ b/src/components/Leaderboard/Leaderboard.tsx
@@ -60,8 +60,9 @@ const styles = (theme: Theme) =>
     noClick: {
       cursor: "initial"
     },
-    shiftRight: {
-      marginLeft: "0.3rem"
+    rank: {
+      padding: 0,
+      justifyContent: "center"
     },
     header: {
       fontWeight: "bold",
@@ -127,7 +128,7 @@ class MuiVirtualizedTable extends React.PureComponent<
         className={clsx(classes.tableCell, classes.flexContainer, {
           [classes.noClick]: onRowClick == null,
           [classes.highlightRow]: rank === 1 || uid === this.props.userId,
-          [classes.shiftRight]: dataKey === "rank" && rank !== 1
+          [classes.rank]: dataKey === "rank"
         })}
         variant="body"
         style={{ height: rowHeight }}


### PR DESCRIPTION
Had to tweak some changes from the previous PR as I didn't account for users with higher ranks than 999 - this should work up to 9999 for all screen sizes

<img width="259" alt="Screenshot 2020-06-06 at 08 13 23" src="https://user-images.githubusercontent.com/29929268/83938600-bc72dd00-a7cd-11ea-8e81-05e64a1260a1.png">
<img width="291" alt="Screenshot 2020-06-06 at 08 13 45" src="https://user-images.githubusercontent.com/29929268/83938601-bd0b7380-a7cd-11ea-8b7f-72a5950c03fd.png">

closes: #91 
