### PR TITLE
Feat/updates to new photo page

### DIFF
--- a/cypress/fixtures/common.ts
+++ b/cypress/fixtures/common.ts
@@ -2,7 +2,8 @@ export const selectors = {
   burger: "Burger",
   emailInput: "#ui-sign-in-email-input",
   passwordInput: "#ui-sign-in-password-input",
-  loginButton: "LoginButton"
+  loginButton: "LoginButton",
+  close: "Close"
 };
 
 export const requestUrls = {

--- a/cypress/integration/routing.test.ts
+++ b/cypress/integration/routing.test.ts
@@ -1,0 +1,24 @@
+import { user } from "../fixtures/users";
+import { routes, selectors } from "../fixtures/common";
+
+describe("routing", () => {
+  it("if a user goes to the tutorial page from the new photo page they are redirected back to the new photo page", () => {
+    cy.login(user.email, user.password);
+
+    cy.visit(routes.newPhoto);
+
+    cy.log("testing routing from close button");
+    cy.contains("tutorial").click();
+    cy.url().should("include", routes.tutorial);
+
+    cy.getTestElement(selectors.close).click();
+    cy.url().should("include", routes.newPhoto);
+
+    cy.log("testing routing from get started button");
+    cy.contains("tutorial").click();
+    cy.getTestElement("NavDot-3").click();
+
+    cy.contains("Get started").click();
+    cy.url().should("include", routes.newPhoto);
+  });
+});

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -137,7 +137,11 @@ export const PhotoPageWrapper: FunctionComponent<PhotoPageProps> = ({
           {nextClicked ? (
             <BackIcon className={classes.iconButton} onClick={handlePrev} />
           ) : (
-            <CloseIcon className={classes.iconButton} onClick={handleClose} />
+            <CloseIcon
+              className={classes.iconButton}
+              onClick={handleClose}
+              data-test="Close"
+            />
           )}
           <Typography className={classes.grow} variant="h6" color="inherit">
             {label}
@@ -239,7 +243,11 @@ const PageWrapper: FunctionComponent<Props> = ({
   if (isCloseNavigationHandler(navigationHandler)) {
     const { handleClose } = navigationHandler;
     navIcon = (
-      <CloseIcon className={classes.iconButton} onClick={handleClose} />
+      <CloseIcon
+        className={classes.iconButton}
+        onClick={handleClose}
+        data-test="Close"
+      />
     );
   } else {
     const { handleBack, confirm } = navigationHandler;

--- a/src/custom/config.tsx
+++ b/src/custom/config.tsx
@@ -31,9 +31,11 @@ const primaryContrastText = styles.primaryContrastText;
 const secondaryMain = styles.secondaryMain;
 const secondaryContrastText = styles.primaryContrastText;
 
+export const linkToMap = () => "/";
+
 const PAGES: { [pageName: string]: Page } = {
   map: {
-    path: "/",
+    path: linkToMap(),
     label: "Map"
   },
   embeddable: {

--- a/src/hooks/useLocationOnMount.ts
+++ b/src/hooks/useLocationOnMount.ts
@@ -1,0 +1,9 @@
+import { useRef } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function useLocationOnMount<P>() {
+  const location = useLocation<P>();
+  const locationRef = useRef(location);
+
+  return locationRef.current;
+}

--- a/src/pages/dialogs/Login.tsx
+++ b/src/pages/dialogs/Login.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from "react";
-import { useLocation, useHistory } from "react-router-dom";
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -11,6 +11,7 @@ import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
 
 import LoginFirebase from "components/LoginFirebase";
+import useLocationOnMount from "hooks/useLocationOnMount";
 
 type Props = { handleClose: () => void };
 
@@ -62,9 +63,8 @@ export default function Login({ handleClose }: Props) {
 }
 
 function useGetRedirectOnSuccess() {
-  const location = useLocation<{ redirectToOnSuccess?: string }>();
-  const locationRef = useRef(location);
-  const locationState = locationRef.current.state;
+  const location = useLocationOnMount<{ redirectToOnSuccess?: string }>();
+  const locationState = location.state;
   const redirectToOnSuccess =
     locationState && locationState.redirectToOnSuccess;
   const history = useHistory();

--- a/src/pages/photo/pages/NewPhotoPage/NewPhotoPage.tsx
+++ b/src/pages/photo/pages/NewPhotoPage/NewPhotoPage.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles((theme) => ({
     background: styles.lightGrey,
     border: `${styles.mediumGrey} solid 1px`,
     "&:focus": { background: styles.lightGrey }
+  },
+  link: {
+    color: theme.palette.primary.main
   }
 }));
 
@@ -45,12 +48,15 @@ export default function NewPhotoPage({
           <AddAPhotoIcon className={styles.icon} />
         </Button>
         <div className={styles.text}>
-          <p>Tap on the button above to add a photo of your cleanup.</p>
+          <p>Tap on the button above to add a photo of litter.</p>
 
-          <p>Make sure items are clearly visible in the photo.</p>
+          <p>Make sure all litter is clearly visible.</p>
           <p>
             If you would like to see an example, please check out the{" "}
-            <Link to={linkToTutorialPage()}>tutorial</Link>.
+            <Link to={linkToTutorialPage()} className={styles.link}>
+              tutorial
+            </Link>
+            .
           </p>
         </div>
       </div>

--- a/src/pages/photo/pages/NewPhotoPage/NewPhotoPage.tsx
+++ b/src/pages/photo/pages/NewPhotoPage/NewPhotoPage.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
 import { Button, makeStyles } from "@material-ui/core";
 import AddAPhotoIcon from "@material-ui/icons/AddAPhoto";
 
@@ -28,8 +30,12 @@ const useStyles = makeStyles((theme) => ({
 
 type Props = {
   onPhotoClick: () => void;
+  linkToTutorialPage: () => string | Object;
 };
-export default function NewPhotoPage({ onPhotoClick }: Props) {
+export default function NewPhotoPage({
+  onPhotoClick,
+  linkToTutorialPage
+}: Props) {
   const styles = useStyles();
 
   return (
@@ -39,13 +45,12 @@ export default function NewPhotoPage({ onPhotoClick }: Props) {
           <AddAPhotoIcon className={styles.icon} />
         </Button>
         <div className={styles.text}>
-          <p>Tap on the button above to add a photo of your cleanup</p>
+          <p>Tap on the button above to add a photo of your cleanup.</p>
 
+          <p>Make sure items are clearly visible in the photo.</p>
           <p>
-            Please make sure items are clearly visible in the photo.
-            <br />
-            If you would like to see an example, please check out the tutorial
-            in the menu bar.
+            If you would like to see an example, please check out the{" "}
+            <Link to={linkToTutorialPage()}>tutorial</Link>.
           </p>
         </div>
       </div>

--- a/src/pages/tutorial/static/index.tsx
+++ b/src/pages/tutorial/static/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
 
 import LocationOn from "@material-ui/icons/LocationOn";
 import CameraAlt from "@material-ui/icons/CameraAlt";
@@ -6,7 +7,10 @@ import CloudUpload from "@material-ui/icons/CloudUpload";
 import Button from "@material-ui/core/Button";
 
 import exampleImage from "assets/images/example.jpeg";
-import { useHistory } from "react-router-dom";
+
+import useLocationOnMount from "hooks/useLocationOnMount";
+
+import { linkToMap } from "custom/config";
 
 export type TutorialStep = {
   img?: string;
@@ -41,11 +45,20 @@ export const tutorialSteps: Array<TutorialStep> = [
       "By litter picking and recording your findings you are helping build the largest and most powerful dataset on litter. We analyse everything you collect to drive impactful and evidence-based changes by government and brands to protect the environment.",
     Button: () => {
       const history = useHistory();
+      const location = useLocationOnMount<{ redirectOnGetStarted?: string }>();
+
+      const locationState = location.state;
+      const redirectOnGetStarted =
+        locationState && locationState.redirectOnGetStarted;
 
       return (
         <Button
           className="FinalSlide__button"
-          onClick={() => history.push("/")}
+          onClick={() =>
+            history.push(
+              redirectOnGetStarted ? redirectOnGetStarted : linkToMap()
+            )
+          }
         >
           Get started
         </Button>

--- a/src/routes/photo/routes/new/Route.tsx
+++ b/src/routes/photo/routes/new/Route.tsx
@@ -1,12 +1,20 @@
 import React, { useState } from "react";
 import { Route, useHistory } from "react-router-dom";
 
-import { NewPhotoPage } from "pages/photo";
-import AddPhotoDialog from "pages/photo/components/AddPhotoDialog";
-
-import { linkToAddDialog } from "./links";
-import { linkToCategoriseWithState } from "../categorise/links";
+import { linkToTutorialPage } from "routes/tutorial/links";
 import { CordovaCameraImage } from "types/Photo";
+import AddPhotoDialog from "pages/photo/components/AddPhotoDialog";
+import { NewPhotoPage } from "pages/photo";
+
+import { linkToCategoriseWithState } from "../categorise/links";
+import { linkToAddDialog, linkToNewPhoto } from "./links";
+
+const linkToTutorialWithRedirect = () => ({
+  pathname: linkToTutorialPage(),
+  state: {
+    redirectOnGetStarted: linkToNewPhoto()
+  }
+});
 
 export default function NewPhotoRoute() {
   const history = useHistory();
@@ -18,6 +26,7 @@ export default function NewPhotoRoute() {
 
   // @ts-ignore
   const isCordova = !!window.cordova;
+
   return (
     <>
       <NewPhotoPage
@@ -26,6 +35,7 @@ export default function NewPhotoRoute() {
             ? history.push(linkToAddDialog())
             : inputRef && inputRef.click();
         }}
+        linkToTutorialPage={linkToTutorialWithRedirect}
       />
       <input
         className="hidden"


### PR DESCRIPTION
Updated the copy - I personally don't think adding a button to redirect to the tutorial is the best idea because it will be one of the last items on the page and is likely to draw users attention as they scan down so have made it a link instead. 
If design wise a button is really what's wanted I'll add it in, just let me know the copy that you want around it

From the tutorial if a user clicks the close icon in the top corner or the `get started` button they will be redirected back to this page

<img width="338" alt="Screenshot 2020-06-28 at 08 23 42" src="https://user-images.githubusercontent.com/29929268/85941101-b5e10c80-b918-11ea-9f14-4dedb486d9ed.png">


closes #101 
