### PR TITLE
Track large collections separately

### DIFF
--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -13,26 +13,45 @@ export interface User {
   groups?: string[];
 }
 
-export interface GroupStats {
+export interface BaseStats {
+  // sum of the # of pieces in all uploads
+  pieces: number;
+
+  // both of these contain the # of uploads.
+  // totalUploaded is needed here backwards compatibility but should
+  // be considered deprecated
+  totalUploaded: number;
+  uploaded: number;
+
+  // large uploads represent individual uploads (photos) with > 1000 pieces.
+  // these are tracked here as a SUBSET of the above fields. so if a user
+  // has 2 uploads, 1 with 2000 pieces and 1 with 1 pieces, the stats would look like:
+  // {
+  //   uploaded: 2,
+  //   totalUploaded: 2,
+  //   pieces: 2001,
+  //   largeCollectionUploads: 1,
+  //   largeCollectionPieces: 2000
+  // }
+  largeCollectionUploads: number;
+  // sum of all pieces in large collections
+  largeCollectionPieces: number;
+}
+
+export interface GroupStats extends BaseStats {
   gid: string;
   displayName: string;
-  pieces: number;
-  uploaded: number;
 }
 
-export interface UserStats {
+export interface UserStats extends BaseStats {
   uid: string;
   displayName: string;
-  pieces: number;
-  uploaded: number;
 }
 
-export interface Stats {
-  totalUploaded: number;
+export interface Stats extends BaseStats {
   moderated: number;
   published: number;
   rejected: number;
-  pieces: number;
   users: UserStats[];
   groups: GroupStats[];
 }


### PR DESCRIPTION
track large collections as separate fields in stats so that the frontend can subtract these from the total if it so chooses