### PR TITLE
💄 add minHeight to image and itemOverview

### DIFF
--- a/src/pages/photo/components/ItemOverview/ItemOverview.tsx
+++ b/src/pages/photo/components/ItemOverview/ItemOverview.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles((theme) => ({
     background: "#4e4e4e",
     color: "white",
     padding: `${theme.spacing(0.5)}px ${theme.spacing(1)}px`,
-    marginBottom: theme.spacing(0.5)
+    marginBottom: theme.spacing(0.5),
+    minHeight: "30px"
   },
   cross: {
     marginLeft: "auto"

--- a/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
+++ b/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
@@ -33,7 +33,9 @@ const useStyles = makeStyles((theme) => ({
     boxSizing: "border-box"
   },
   img: {
+    minHeight: "50%",
     height: "50%",
+    width: "100%",
     alignSelf: "center",
     marginBottom: theme.spacing(1)
   },


### PR DESCRIPTION
Closes #143 

On safari the items got squashed, noticed on chrome that the image gets squashed instead