### PR TITLE
errors thrown inside the uploadTask.on method cannot by caught

### DIFF
--- a/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
+++ b/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
@@ -96,7 +96,6 @@ async function sendFile({
   } catch (error) {
     console.error(error);
 
-    // debugger
     const extraInfo =
       error.message === "storage/canceled"
         ? ""
@@ -109,8 +108,7 @@ async function sendFile({
 
   setUploadTask(uploadTask);
 
-  uploadTask.on(
-    "state_changed",
+  uploadTask.on(firebase.storage.TaskEvent.STATE_CHANGED,
     (snapshot) => {
       const sendingProgress = Math.ceil(
         (snapshot.bytesTransferred / snapshot.totalBytes) * 98 + 1
@@ -127,22 +125,24 @@ async function sendFile({
         default:
           console.log(snapshot.state);
       }
-    },
-    (error) => {
-      // @ts-ignore
-      if (error.code === "storage/canceled") {
-        onCancelUpload();
-      } else {
-        console.log(error);
-        const extraInfo =
-          error.message === "storage/canceled"
-            ? ""
-            : `Try again (${error.message})`;
-        throw Error(`Photo upload was canceled. ${extraInfo}`);
-      }
-    },
-    () => {
+    });
+
+  await uploadTask.then(() => {
       history.push(linkToUploadSuccess(totalCount as any));
     }
   );
+
+  await uploadTask.catch((error) => {
+    // @ts-ignore
+    if (error.code === "storage/canceled") {
+      onCancelUpload();
+    } else {
+      console.log(error);
+      const extraInfo =
+        error.message === "storage/canceled"
+          ? ""
+          : `Try again (${error.message})`;
+      throw Error(`Photo upload was canceled. ${extraInfo}`);
+    }
+  });
 }


### PR DESCRIPTION
for #134 bringing the on error call back function inside a promise so that the error can be caught.

This is not a complete fix nor I've tested it properly. So take it as just a step forward.

Still to fix: after catching the error, the "upload" message need to be closed. (related to https://github.com/PlasticPatrol/PlasticPatrolWeb/issues/203)