### PR TITLE
Cache photos with timestamp

### DIFF
--- a/cordova-app/config.xml
+++ b/cordova-app/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="20140000" id="uk.co.plasticpatrol" ios-CFBundleIdentifier="com.lewismakesapps.Plastic-Patrol" ios-CFBundleVersion="2.14.0" version="2.14.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="20180000" id="uk.co.plasticpatrol" ios-CFBundleIdentifier="com.lewismakesapps.Plastic-Patrol" ios-CFBundleVersion="2.18.0" version="2.18.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Planet Patrol</name>
     <description>
         Fighting Pollution in the UK Waterways.

--- a/cordova-app/config.xml
+++ b/cordova-app/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="20180000" id="uk.co.plasticpatrol" ios-CFBundleIdentifier="com.lewismakesapps.Plastic-Patrol" ios-CFBundleVersion="2.18.0" version="2.18.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="20200000" id="uk.co.plasticpatrol" ios-CFBundleIdentifier="com.lewismakesapps.Plastic-Patrol" ios-CFBundleVersion="2.20.0" version="2.20.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Planet Patrol</name>
     <description>
         Fighting Pollution in the UK Waterways.

--- a/cordova-app/package-lock.json
+++ b/cordova-app/package-lock.json
@@ -140,11 +140,11 @@
       }
     },
     "android-versions": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.5.0.tgz",
-      "integrity": "sha512-/GWUAqa2OJNlDF5VGSe3SR1QMHEPXxx54Ur56r0qQC0H9FlBr7kyBF2SgVEhzFCPbrW4UcYgVuWrq/2Ty3QvXg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.6.0.tgz",
+      "integrity": "sha512-ojC2Ig7b/KJ6iNtR8e4bacmOsJyEkoERk3CKMIsnH7kJz5z6551NMbrVaRb7KXYavu1d74Uhml/bfcmqT3nAcg==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "^5.7.1"
       }
     },
     "ansi": {
@@ -422,6 +422,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/cordova-plugin-customurlscheme/-/cordova-plugin-customurlscheme-5.0.1.tgz",
       "integrity": "sha512-Nn3+MUrEGfBSFzkC9s5izzOcmpVy8Pya5oYF+CkcdqAlsqL7EqpUan3Q0Eold4EWFisVG5jRCg0XjyxL4uHGfw=="
+    },
+    "cordova-plugin-device": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-2.0.3.tgz",
+      "integrity": "sha512-Jb3V72btxf3XHpkPQsGdyc8N6tVBYn1vsxSFj43fIz9vonJDUThYPCJJHqk6PX6N4dJw6I4FjxkpfCR4LDYMlw=="
     },
     "cordova-plugin-firebase-analytics": {
       "version": "3.0.0",

--- a/cordova-app/package.json
+++ b/cordova-app/package.json
@@ -5,8 +5,8 @@
   "homepage": "./",
   "cordova": {
     "platforms": [
-      "android",
-      "ios"
+      "ios",
+      "android"
     ],
     "plugins": {
       "cordova-plugin-whitelist": {},
@@ -34,7 +34,8 @@
       "phonegap-plugin-barcodescanner": {},
       "sentry-cordova": {
         "SENTRY_ANDROID_SDK_VERSION": "1+"
-      }
+      },
+      "cordova-plugin-device": {}
     }
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "cordova-plugin-camera-with-exif": "^1.3.1",
     "cordova-plugin-compat": "^1.2.0",
     "cordova-plugin-customurlscheme": "^5.0.1",
+    "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-firebase-analytics": "^3.0.0",
     "cordova-plugin-geolocation": "^4.0.1",
     "cordova-plugin-inappbrowser": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plastic-patrol",
   "title": "Plastic Patrol",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "public": true,
   "homepage": "./",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plastic-patrol",
   "title": "Plastic Patrol",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "public": true,
   "homepage": "./",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plastic-patrol",
   "title": "Plastic Patrol",
-  "version": "2.17.5",
+  "version": "2.19.0",
   "public": true,
   "homepage": "./",
   "dependencies": {

--- a/src/components/LoginFirebase.js
+++ b/src/components/LoginFirebase.js
@@ -21,11 +21,10 @@ const LoginFirebase = (props) => {
   const uiConfig = {
     signInSuccessUrl: "/",
     credentialHelper: firebaseui.auth.CredentialHelper.NONE,
-    signInOptions:
-      [
-        firebase.auth.FacebookAuthProvider.PROVIDER_ID,
-        firebase.auth.EmailAuthProvider.PROVIDER_ID
-      ] + [devicePlatform === "Android" ? [] : "apple.com"],
+    signInOptions: [
+      firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+      firebase.auth.EmailAuthProvider.PROVIDER_ID
+    ].concat(devicePlatform === "Android" ? [] : ["apple.com"]),
     callbacks: {
       // Avoid redirects after sign-in.
       signInSuccessWithAuthResult: (result) => {

--- a/src/components/LoginFirebase.js
+++ b/src/components/LoginFirebase.js
@@ -13,17 +13,19 @@ import { authFirebase } from "features/firebase";
 
 // TODO: change theme: https://github.com/firebase/firebaseui-web-react/tree/master/dist
 
+const devicePlatform = window.device && window.device.platform;
+
 const LoginFirebase = (props) => {
   const { open, handleClose, onSignIn } = props;
 
   const uiConfig = {
     signInSuccessUrl: "/",
     credentialHelper: firebaseui.auth.CredentialHelper.NONE,
-    signInOptions: [
-      firebase.auth.FacebookAuthProvider.PROVIDER_ID,
-      firebase.auth.EmailAuthProvider.PROVIDER_ID,
-      "apple.com"
-    ],
+    signInOptions:
+      [
+        firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+        firebase.auth.EmailAuthProvider.PROVIDER_ID
+      ] + [devicePlatform === "Android" ? [] : "apple.com"],
     callbacks: {
       // Avoid redirects after sign-in.
       signInSuccessWithAuthResult: (result) => {

--- a/src/index.js
+++ b/src/index.js
@@ -42,13 +42,6 @@ if (isIphoneAndCordova) {
   window.StatusBar.styleDefault();
 }
 
-const isPendingRedirect = () => {
-  const app =
-    firebaseui.auth.AuthUI.getInstance() ||
-    new firebaseui.auth.AuthUI(firebase.auth());
-  return app.isPendingRedirect();
-};
-
 if (
   process.env.NODE_ENV !== "development" &&
   localStorage.getItem("debug") !== "true"

--- a/src/pages/welcome/WelcomePage/WelcomePage.scss
+++ b/src/pages/welcome/WelcomePage/WelcomePage.scss
@@ -2,6 +2,7 @@
 
 .WelcomePage__container {
   width: 100vw;
+  height: 100vh;
   //TODO: get new asset so $secondary can be used
   background: $primaryMain;
   position: absolute;

--- a/src/providers/PhotosProvider.tsx
+++ b/src/providers/PhotosProvider.tsx
@@ -140,6 +140,7 @@ export const usePhotos = (): [PhotosContainer, () => void] => {
     // set up realtime subscription to our own photos
 
     // use the local one if we have them: faster boot.
+    /*
     try {
       const cached = await localforage.getItem("cachedGeoJson");
       if (cached) {
@@ -152,6 +153,15 @@ export const usePhotos = (): [PhotosContainer, () => void] => {
           merge(current, photosToPhotosContainer(photosList))
         );
       }
+    } catch (e) {
+      console.error(e);
+    }
+    */
+    try {
+      const photosList = await dbFirebase.fetchPhotos();
+      setPhotos((current) =>
+        merge(current, photosToPhotosContainer(photosList))
+      );
     } catch (e) {
       console.error(e);
     }

--- a/src/types/Geojson.ts
+++ b/src/types/Geojson.ts
@@ -1,5 +1,14 @@
 import Feature from "types/Feature";
 
+export type CachedGeojson = {
+  timestamp: number; // ms since epoch, like in Date
+  geojson: Geojson;
+};
+
+export const isCachedGeojson = (obj: any): obj is CachedGeojson => {
+  return obj && obj.timestamp !== undefined && obj.geojson !== undefined;
+};
+
 type Geojson = {
   type: "FeatureCollection";
   features: Feature[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,7 +4571,6 @@
 "@types/uuid@^8.0.0":
   version "8.0.0"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz#165aae4819ad2174a17476dbe66feebd549556c0"
-  integrity sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
 
 "@types/webpack-env@^1.15.0":
   version "1.15.2"
@@ -7299,7 +7298,6 @@ cross-env@^5.1.3:
 cross-env@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
-  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
   dependencies:
     cross-spawn "^7.0.1"
 
@@ -7346,7 +7344,6 @@ cross-spawn@^5.0.1:
 cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -12886,9 +12883,8 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 mapbox-gl@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.11.1.tgz#063e72b591d506b6b1f483df563e3e48cd0a971b"
-  integrity sha512-UjXpPUTUzHTLfhl5dLefwV3Jgu7DN9phpn8RnnkQVe1sOXfVYMS5Vhjn225krhzRc7xnKIBHxLyu0rHZGyeXuQ==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.12.0.tgz#7d1c73b1153d7ee219d30d80728d7df079bc7c05"
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.0"
     "@mapbox/geojson-types" "^1.0.2"
@@ -17558,7 +17554,6 @@ stylehacks@^4.0.0:
 supercluster@^7.1.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz#f0a457426ec0ab95d69c5f03b51e049774b94479"
-  integrity sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==
   dependencies:
     kdbush "^3.0.0"
 
@@ -18531,7 +18526,6 @@ uuid@^7.0.0:
 uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
There was a bug in https://github.com/PlasticPatrol/PlasticPatrolWeb/pull/145/files which prevented the cache from being updated. This means that photos (except for your own which are fetched separately) would grow stale until the cache was deleted (potentially due to storage space, we don't have metrics right now on how often we're hitting/missing cache). This PR adds the cache setting functionality back and also sets a timestamp on the cache so that we can purge it after 30 days. 