### PR TITLE
use uid for displayName if displayName not present

### DIFF
--- a/functions/src/stats.ts
+++ b/functions/src/stats.ts
@@ -21,6 +21,18 @@ export const updateStatsWithPieces = (
   }
 };
 
+/*
+ * Use the display name on the user record itself if present,
+ * otherwise just use the UID
+ */
+const getDisplayName = (user: admin.auth.UserRecord): string => {
+  if (user.displayName) {
+    return user.displayName;
+  } else {
+    return user.uid;
+  }
+};
+
 /**
  * compute the stats from the given data about users, groups and photos
  */
@@ -33,7 +45,7 @@ export const computeStats = (
   const users: UserStats[] = rawUsers.map((user) => {
     const userShort = {
       uid: user.uid,
-      displayName: user.displayName || "",
+      displayName: getDisplayName(user),
       pieces: 0,
       totalUploaded: 0,
       uploaded: 0,
@@ -110,7 +122,6 @@ export const computeStats = (
 
         if (owner) {
           updateStatsWithPieces(owner, pieces);
-          owner.displayName = owner.displayName || "";
         }
       } else {
         stats.rejected++;

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -1,0 +1,17 @@
+const admin = require("firebase-admin");
+const yargs = require("yargs");
+admin.initializeApp();
+const auth = admin.auth();
+
+const argv = yargs
+  .option("id", {
+    description: "UID of the user to inspect",
+    type: "string"
+  })
+  .help()
+  .alias("help", "h").argv;
+
+(async function () {
+  const user = await auth.getUser(argv.id);
+  console.log(JSON.stringify(user));
+})();

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -3,12 +3,20 @@ const yargs = require("yargs");
 const { PubSub } = require("@google-cloud/pubsub");
 const prompt = require("prompt-sync")();
 
-const COMPUTE_STATS_URL =
+const COMPUTE_STATS_URL_DEV =
   "https://us-central1-plastic-patrol-dev-722eb.cloudfunctions.net/computeStats";
-const FETCH_STATS_URL =
+const FETCH_STATS_URL_DEV =
   "https://us-central1-plastic-patrol-dev-722eb.cloudfunctions.net/api/stats";
+const COMPUTE_STATS_URL =
+  "https://us-central1-plastic-patrol-fd3b3.cloudfunctions.net/computeStats";
+const FETCH_STATS_URL =
+  "https://us-central1-plastic-patrol-fd3b3.cloudfunctions.net/api/stats";
 
 const argv = yargs
+  .option("prod", {
+    description: "Get data from production",
+    type: "boolean"
+  })
   .option("save", {
     description: "Save the stats to firebase",
     type: "boolean"
@@ -39,10 +47,17 @@ const argv = yargs
   }
 
   const result = await fetch(
-    argv.compute ? COMPUTE_STATS_URL : FETCH_STATS_URL
+    argv.compute
+      ? argv.prod
+        ? COMPUTE_STATS_URL
+        : COMPUTE_STATS_URL_DEV
+      : argv.prod
+      ? FETCH_STATS_URL
+      : FETCH_STATS_URL_DEV
   );
   const stats = await result.json();
-  console.log(stats);
+  console.log(JSON.stringify(stats));
+
   if (argv.save !== true) {
     return;
   }


### PR DESCRIPTION
firebase doesn't have displayNames for all users. I'm not sure what the logic is on Firebase side to figure out when a user should have a display name (some appleID users do have it, others dont). We should just use the uid if the displayName isn't there, and should probably do the same thing in our account page. Then we need to update the account page to let users edit their information.