### PR TITLE
add default icon that will be used if pixel dimensions don't match

### DIFF
--- a/cordova-app/config.xml
+++ b/cordova-app/config.xml
@@ -50,6 +50,7 @@
         <icon src="res/icon/ios/icon_76pt@2x.png" width="152"/>
         <icon src="res/icon/ios/icon_83.5@2x.png" width="167"/>
         <icon src="res/icon/ios/Icon.png" width="1024"/>
+        <icon src="res/icon/ios/Icon.png"/>
         <splash src="res/screen/ios/Default@2x~universal~anyany.png"/>
         <resource-file src="GoogleService-Info.plist"/>
         <preference name="DisallowOverscroll" value="true"/>

--- a/cordova-app/package.json
+++ b/cordova-app/package.json
@@ -5,8 +5,8 @@
   "homepage": "./",
   "cordova": {
     "platforms": [
-      "ios",
-      "android"
+      "android",
+      "ios"
     ],
     "plugins": {
       "cordova-plugin-whitelist": {},


### PR DESCRIPTION
according to https://cordova.apache.org/docs/en/latest/config_ref/images.html `<icon src="res/icon/ios/Icon.png"/>` will be used as a default if no pixel-perfect width/height icon is matched