### PR TITLE
feature/manage categories page

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -50,7 +50,8 @@ service cloud.firestore {
     // data written by admin
     match /users/{uid} {
     	allow read: if isAdmin() || isUser(uid);
-      allow write: if isAdmin();
+      // Temporarily making true to enable mission owners to add pending users to missions.
+      allow write: if isAdmin() || isUser(uid) || true;
     }
 
     // Collection with system data. The Doc stats contains statistics.
@@ -61,6 +62,42 @@ service cloud.firestore {
     // some extra config
     match /sys/config {
       allow read: if true;
+    }
+    
+    // data written by admin
+    match /missions/{missionId} {
+    
+      function isMissionOwner() {
+        return get(/databases/$(database)/documents/missions/$(missionId)).data.ownerUserId == request.auth.uid;
+      }	
+      
+      function isPrivateMission() {
+        return get(/databases/$(database)/documents/missions/$(missionId)).data.isPrivate == true;
+      }	
+    
+      allow create: if true;
+    	allow read: if true;
+      // Workaround as true because people need to be able to add themselvse to public missions
+      // and add themselves as pending members to private missions.
+      allow write: if true;
+    }
+
+    match /categories {
+    	allow read: if true
+    }
+    
+    match /categories/{categoryId} {
+    	allow read: if true
+      allow write: if isModerator() || isAdmin();
+    }
+    
+    match /brands {
+    	allow read: if true
+    }
+    
+    match /brands/{brandId} {
+    	allow read: if true
+      allow write: if isModerator() || isAdmin();
     }
   }
 }

--- a/scripts/migration/storeBrandsInFirebase.ts
+++ b/scripts/migration/storeBrandsInFirebase.ts
@@ -1,0 +1,42 @@
+const admin = require("firebase-admin");
+
+const brands = require("../../src/custom/brands.json");
+const serviceAccount = require("../../adminCreds.test.json");
+
+const brandsPath = () => "brands";
+const brand = (brandId: string) => `${brandsPath()}/${brandId}`;
+
+// get credentials to run this from https://console.firebase.google.com/u/0/project/plastic-patrol-dev-722eb/settings/serviceaccounts/adminsdk
+
+async function storeCategories() {
+  console.log("Initialising");
+  admin.initializeApp({
+    // @ts-ignore
+    credential: admin.credential.cert(serviceAccount),
+    databaseURL: "https://plastic-patrol-dev-test.firebaseio.com"
+  });
+  const firestore = admin.firestore();
+  const bulkWriter = firestore.bulkWriter();
+
+  console.log("Writing");
+
+  Object.keys(brands).forEach((key) => {
+    // @ts-ignore
+    bulkWriter.create(firestore.doc(brand(key)), brands[key]);
+  });
+
+  await bulkWriter.close();
+
+  await admin.app().delete();
+  console.log("Added all brands!");
+
+  process.exit(0);
+}
+
+storeCategories().catch(async (err) => {
+  console.error(err);
+
+  await admin.app().delete();
+
+  process.exit(1);
+});

--- a/scripts/migration/storeCategoriesInFirebase.ts
+++ b/scripts/migration/storeCategoriesInFirebase.ts
@@ -1,0 +1,42 @@
+const admin = require("firebase-admin");
+
+const categories = require("../../src/custom/categories.json");
+const serviceAccount = require("../../adminCreds.test.json");
+
+const categoriesPath = () => "categories";
+const category = (categoryId: string) => `${categoriesPath()}/${categoryId}`;
+
+// get credentials to run this from https://console.firebase.google.com/u/0/project/plastic-patrol-dev-722eb/settings/serviceaccounts/adminsdk
+
+async function storeCategories() {
+  console.log("Initialising");
+  admin.initializeApp({
+    // @ts-ignore
+    credential: admin.credential.cert(serviceAccount),
+    databaseURL: "https://plastic-patrol-dev-test.firebaseio.com"
+  });
+  const firestore = admin.firestore();
+  const bulkWriter = firestore.bulkWriter();
+
+  console.log("Writing");
+
+  Object.keys(categories).forEach((key) => {
+    // @ts-ignore
+    bulkWriter.create(firestore.doc(category(key)), categories[key]);
+  });
+
+  await bulkWriter.close();
+
+  await admin.app().delete();
+  console.log("Added all categories!");
+
+  process.exit(0);
+}
+
+storeCategories().catch(async (err) => {
+  console.error(err);
+
+  await admin.app().delete();
+
+  process.exit(1);
+});

--- a/src/features/firebase/brands/BrandsProvider.tsx
+++ b/src/features/firebase/brands/BrandsProvider.tsx
@@ -1,10 +1,12 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+import orginal from "custom/brands.json";
+
 import { fetchBrands, ServerBrand } from ".";
 
 type BrandJson = { [key: string]: ServerBrand };
 
 export default function BrandsProvider({ children }: any) {
-  const [brands, setBrands] = useState({});
+  const [brands, setBrands] = useState<BrandJson>(orginal);
 
   useEffect(() => {
     async function fetchAndReduce() {

--- a/src/features/firebase/brands/BrandsProvider.tsx
+++ b/src/features/firebase/brands/BrandsProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { fetchBrands, ServerBrand } from ".";
+
+type BrandJson = { [key: string]: ServerBrand };
+
+export default function BrandsProvider({ children }: any) {
+  const [brands, setBrands] = useState({});
+
+  useEffect(() => {
+    async function fetchAndReduce() {
+      const brands = await fetchBrands();
+
+      const json = brands.reduce((reduction, { id, ...rest }) => {
+        reduction[id] = rest;
+
+        return reduction;
+      }, {} as BrandJson);
+
+      setBrands(json);
+    }
+
+    fetchAndReduce();
+  }, []);
+
+  return (
+    <BrandContext.Provider value={brands}>{children}</BrandContext.Provider>
+  );
+}
+
+const BrandContext = createContext<BrandJson>({});
+
+export const useBrands = () => useContext(BrandContext);

--- a/src/features/firebase/brands/index.ts
+++ b/src/features/firebase/brands/index.ts
@@ -1,0 +1,33 @@
+import firebase from "firebase/app";
+
+const firestore = firebase.firestore();
+
+const brandsPath = () => "brands";
+const brand = (brandId: string) => `${brandsPath()}/${brandId}`;
+
+export type ServerBrand = {
+  label: string;
+  synonyms?: string[];
+};
+export type Brand = {
+  id: string;
+} & ServerBrand;
+
+export const fetchBrands = async () => {
+  const snap = await firestore.collection(brandsPath()).get();
+
+  return snap.docs.map((val) => ({
+    ...val.data(),
+    id: val.id
+  })) as Brand[];
+};
+
+export async function addBrand(brand: ServerBrand) {
+  const res = await firestore.collection(brandsPath()).add(brand);
+
+  return { id: res.id, ...brand } as Brand;
+}
+
+export async function addSynonyms(id: string, synonms: string[]) {
+  await firestore.doc(brand(id)).update({ synonms });
+}

--- a/src/features/firebase/categories/CategoriesProvider.tsx
+++ b/src/features/firebase/categories/CategoriesProvider.tsx
@@ -1,10 +1,12 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+
+import orginal from "custom/categories.json";
 import { fetchCategories, ServerCategory } from ".";
 
 type CategoryJson = { [key: string]: ServerCategory };
 
 export default function CategoriesProvider({ children }: any) {
-  const [categories, setCategories] = useState({});
+  const [categories, setCategories] = useState<CategoryJson>(orginal);
 
   useEffect(() => {
     async function fetchAndReduce() {

--- a/src/features/firebase/categories/CategoriesProvider.tsx
+++ b/src/features/firebase/categories/CategoriesProvider.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { fetchCategories, ServerCategory } from ".";
+
+type CategoryJson = { [key: string]: ServerCategory };
+
+export default function CategoriesProvider({ children }: any) {
+  const [categories, setCategories] = useState({});
+
+  useEffect(() => {
+    async function fetchAndReduce() {
+      const categories = await fetchCategories();
+
+      const json = categories.reduce((reduction, { id, ...rest }) => {
+        reduction[id] = rest;
+
+        return reduction;
+      }, {} as CategoryJson);
+
+      setCategories(json);
+    }
+
+    fetchAndReduce();
+  }, []);
+
+  return (
+    <CategoryContext.Provider value={categories}>
+      {children}
+    </CategoryContext.Provider>
+  );
+}
+
+const CategoryContext = createContext<CategoryJson>({});
+
+export const useCategoriesJson = () => useContext(CategoryContext);

--- a/src/features/firebase/categories/index.ts
+++ b/src/features/firebase/categories/index.ts
@@ -1,0 +1,30 @@
+import firebase from "firebase/app";
+
+const firestore = firebase.firestore();
+
+const categoriesPath = () => "categories";
+const category = (categoryId: string) => `${categoriesPath()}/${categoryId}`;
+
+export type ServerCategory = {
+  label: string;
+  synonyms?: string[];
+};
+export type Category = {
+  id: string;
+} & ServerCategory;
+
+export const fetchCategories = async () => {
+  const snap = await firestore.collection(categoriesPath()).get();
+
+  return snap.docs.map((val) => ({ ...val.data(), id: val.id })) as Category[];
+};
+
+export async function addCategory(category: ServerCategory) {
+  const res = await firestore.collection(categoriesPath()).add(category);
+
+  return { id: res.id, ...category } as Category;
+}
+
+export async function addSynonyms(id: string, synonms: string[]) {
+  await firestore.doc(category(id)).update({ synonms });
+}

--- a/src/features/firebase/categories/index.ts
+++ b/src/features/firebase/categories/index.ts
@@ -16,7 +16,10 @@ export type Category = {
 export const fetchCategories = async () => {
   const snap = await firestore.collection(categoriesPath()).get();
 
-  return snap.docs.map((val) => ({ ...val.data(), id: val.id })) as Category[];
+  return snap.docs.map((val) => ({
+    ...val.data(),
+    id: val.id
+  })) as Category[];
 };
 
 export async function addCategory(category: ServerCategory) {

--- a/src/pages/admin/brands/Brands.tsx
+++ b/src/pages/admin/brands/Brands.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from "react";
+import {
+  fetchBrands,
+  Brand,
+  addBrand,
+  addSynonyms
+} from "features/firebase/brands";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow
+} from "@material-ui/core";
+
+export default function BrandsManagementPage() {
+  const [categories, setBrands] = useState<Brand[]>([]);
+
+  useEffect(() => {
+    async function fetchEm() {
+      const fromServer = await fetchBrands();
+
+      setBrands(
+        fromServer.sort((a, b) => {
+          if (a.label < b.label) {
+            return -1;
+          }
+          if (a.label > b.label) {
+            return 1;
+          }
+          return 0;
+        })
+      );
+    }
+
+    fetchEm();
+  }, []);
+
+  return (
+    <Table size="small" aria-label="a dense table">
+      <TableHead>
+        <TableRow>
+          <TableCell>Id</TableCell>
+          <TableCell>Label</TableCell>
+          <TableCell>Synonyms</TableCell>
+          <TableCell>Add synonyms</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <Newbrand categories={categories} setBrands={setBrands} />
+        {categories.map((brand) => (
+          <BrandRow {...brand} key={brand.id} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function BrandRow(brand: Brand) {
+  const [newSynonyms, setNewSynonyms] = useState("");
+  const [synonyms, setSynonyms] = useState<string[]>(brand.synonyms || []);
+
+  return (
+    <TableRow>
+      <TableCell component="th" scope="row">
+        {brand.id}
+      </TableCell>
+      <TableCell>{brand.label}</TableCell>
+      <TableCell>{synonyms.join(", ")}</TableCell>
+      <TableCell>
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const sanitized = sanitiseSynonyms(newSynonyms);
+            if (sanitized.length === 0) {
+              return;
+            }
+
+            const updatedSynonyms = [...synonyms, ...sanitized];
+            await addSynonyms(brand.id, updatedSynonyms);
+            setNewSynonyms("");
+            setSynonyms(updatedSynonyms);
+          }}
+        >
+          <input
+            style={{ width: "100%" }}
+            placeholder="comma separate different values"
+            value={newSynonyms}
+            onChange={(e) => setNewSynonyms(e.target.value)}
+          />
+          <Button type="submit">add</Button>
+        </form>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function Newbrand({
+  categories,
+  setBrands
+}: {
+  categories: Brand[];
+  setBrands: any;
+}) {
+  const [label, setLabel] = useState("");
+  const [synonyms, setSynonyms] = useState("");
+
+  async function submit() {
+    const sanitisedLabel = label.trim();
+
+    if (sanitisedLabel.length === 0) {
+      return;
+    }
+
+    // TODO: fuzzy match against existing categories to avoid duplicates
+
+    const newbrand = await addBrand({
+      label: sanitisedLabel,
+      synonyms: sanitiseSynonyms(synonyms)
+    });
+
+    setBrands((old: any) => {
+      return [...old, newbrand];
+    });
+
+    setLabel("");
+    setSynonyms("");
+  }
+
+  return (
+    <TableRow>
+      <TableCell component="th" scope="row">
+        <Button onClick={submit}>Add</Button>
+      </TableCell>
+      <TableCell>
+        <input
+          style={{ width: "100%" }}
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+        />
+      </TableCell>
+      <TableCell>
+        <input
+          style={{ width: "100%" }}
+          placeholder="comma separate different values"
+          value={synonyms}
+          onChange={(e) => setSynonyms(e.target.value)}
+        />
+      </TableCell>
+      <TableCell></TableCell>
+    </TableRow>
+  );
+}
+
+function sanitiseSynonyms(synonyms: string) {
+  return synonyms.split(",").map((v) => v.trim());
+}

--- a/src/pages/admin/categories/Categories.tsx
+++ b/src/pages/admin/categories/Categories.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from "react";
+import {
+  fetchCategories,
+  Category,
+  addCategory,
+  addSynonyms
+} from "features/firebase/categories";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow
+} from "@material-ui/core";
+
+export default function CategoriesManagementPage() {
+  const [categories, setCategories] = useState<Category[]>([]);
+
+  useEffect(() => {
+    async function fetchEm() {
+      const fromServer = await fetchCategories();
+
+      setCategories(
+        fromServer.sort((a, b) => {
+          if (a.label < b.label) {
+            return -1;
+          }
+          if (a.label > b.label) {
+            return 1;
+          }
+          return 0;
+        })
+      );
+    }
+
+    fetchEm();
+  }, []);
+
+  return (
+    <Table size="small" aria-label="a dense table">
+      <TableHead>
+        <TableRow>
+          <TableCell>Id</TableCell>
+          <TableCell>Label</TableCell>
+          <TableCell>Synonyms</TableCell>
+          <TableCell>Add synonyms</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <NewCategory categories={categories} setCategories={setCategories} />
+        {categories.map((category) => (
+          <CategoryRow {...category} key={category.id} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function CategoryRow(category: Category) {
+  const [newSynonyms, setNewSynonyms] = useState("");
+  const [synonyms, setSynonyms] = useState<string[]>(category.synonyms || []);
+
+  return (
+    <TableRow>
+      <TableCell component="th" scope="row">
+        {category.id}
+      </TableCell>
+      <TableCell>{category.label}</TableCell>
+      <TableCell>{synonyms.join(", ")}</TableCell>
+      <TableCell>
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const sanitized = sanitiseSynonyms(newSynonyms);
+            if (sanitized.length === 0) {
+              return;
+            }
+
+            const updatedSynonyms = [...synonyms, ...sanitized];
+            await addSynonyms(category.id, updatedSynonyms);
+            setNewSynonyms("");
+            setSynonyms(updatedSynonyms);
+          }}
+        >
+          <input
+            style={{ width: "100%" }}
+            placeholder="comma separate different values"
+            value={newSynonyms}
+            onChange={(e) => setNewSynonyms(e.target.value)}
+          />
+          <Button type="submit">add</Button>
+        </form>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function NewCategory({
+  categories,
+  setCategories
+}: {
+  categories: Category[];
+  setCategories: any;
+}) {
+  const [label, setLabel] = useState("");
+  const [synonyms, setSynonyms] = useState("");
+
+  async function submit() {
+    const sanitisedLabel = label.trim();
+
+    if (sanitisedLabel.length === 0) {
+      return;
+    }
+
+    // TODO: fuzzy match against existing categories to avoid duplicates
+
+    const newCategory = await addCategory({
+      label: sanitisedLabel,
+      synonyms: sanitiseSynonyms(synonyms)
+    });
+
+    setCategories((old: any) => {
+      return [...old, newCategory];
+    });
+
+    setLabel("");
+    setSynonyms("");
+  }
+
+  return (
+    <TableRow>
+      <TableCell component="th" scope="row">
+        <Button onClick={submit}>Add</Button>
+      </TableCell>
+      <TableCell>
+        <input
+          style={{ width: "100%" }}
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+        />
+      </TableCell>
+      <TableCell>
+        <input
+          style={{ width: "100%" }}
+          placeholder="comma separate different values"
+          value={synonyms}
+          onChange={(e) => setSynonyms(e.target.value)}
+        />
+      </TableCell>
+      <TableCell></TableCell>
+    </TableRow>
+  );
+}
+
+function sanitiseSynonyms(synonyms: string) {
+  return synonyms.split(",").map((v) => v.trim());
+}

--- a/src/pages/photo/components/AddNewItem/AddNewItem.tsx
+++ b/src/pages/photo/components/AddNewItem/AddNewItem.tsx
@@ -4,10 +4,11 @@ import { Button, makeStyles } from "@material-ui/core";
 import { Item, SuggestionBasedText } from "../../types";
 import QuantitySelector from "../QuantitySelector";
 import SuggestionBasedInput from "../SuggestionBasedInput";
-import categories from "custom/categories.json";
+
 import brands from "custom/brands.json";
 
 import styles from "standard.scss";
+import { useCategoriesJson } from "features/firebase/categories/CategoriesProvider";
 
 type Props = {
   onCancelClick: () => void;
@@ -43,22 +44,10 @@ const useStyles = makeStyles((theme) => ({
       outline: "none"
     }
   },
-  brand: {
-    border: "none",
-    background: styles.lightGrey,
-    color: "black",
-    fontWeight: "bold",
-    marginLeft: theme.spacing(1),
-    fontSize: 11,
-    width: "100%",
-    "&:focus": {
-      outline: "none"
-    }
-  },
   wrapper: {
     display: "grid",
     gridTemplateAreas: `
-    "type type"
+    "category category"
     "brand brand"
     "quantityText quantitySelector"
     "cancel add"
@@ -68,8 +57,11 @@ const useStyles = makeStyles((theme) => ({
     gridTemplateRows: "1fr min-content min-content min-content",
     maxWidth: window.outerWidth - theme.spacing(2)
   },
-  type: {
-    gridArea: "type"
+  category: {
+    gridArea: "category"
+  },
+  brand: {
+    gridArea: "brand"
   },
   quantityText: {
     gridArea: "quantityText",
@@ -94,14 +86,16 @@ export default function AddNewItem({
   initialItem
 }: Props) {
   const [quantity, setQuantity] = useState(initialItem?.quantity || 0);
-  const [type, setType] = useState<SuggestionBasedText>(
-    initialItem?.type || { leafKey: null, label: null }
+  const [category, setCategory] = useState<SuggestionBasedText>(
+    initialItem?.category || { label: null, id: null }
   );
   const [brand, setBrand] = useState<string>(initialItem?.brand || "");
 
   const styles = useStyles();
 
-  const itemButtonIsDisabled = !(quantity && type && type.label);
+  const itemButtonIsDisabled = !(quantity && category && category.label);
+
+  const categories = useCategoriesJson();
 
   return (
     <div className={styles.wrapper}>
@@ -111,20 +105,20 @@ export default function AddNewItem({
           inputPrompt={
             'Search for the litter type e.g. "plastic bottle" or "crisp packet"'
           }
-          setType={setType}
-          className={styles.type}
-          initialLabel={initialItem?.type?.label || ""}
+          callback={setCategory}
+          initialLabel={initialItem?.category?.label || ""}
+          className={styles.category}
         />
         <SuggestionBasedInput
           sourceData={brands}
           inputPrompt={
             'Search for the litter brand e.g. "Coca Cola" or "Cadbury"'
           }
-          setType={(suggestion: SuggestionBasedText) =>
+          callback={(suggestion: SuggestionBasedText) =>
             setBrand(suggestion?.label || "")
           }
-          className={styles.type}
           initialLabel={initialItem?.brand}
+          className={styles.brand}
         />
       </div>
       <p className={styles.quantityText}>Quantity</p>
@@ -146,7 +140,7 @@ export default function AddNewItem({
         onClick={() =>
           onConfirmClick({
             quantity,
-            type,
+            category,
             brand
           })
         }

--- a/src/pages/photo/components/AddNewItem/AddNewItem.tsx
+++ b/src/pages/photo/components/AddNewItem/AddNewItem.tsx
@@ -5,10 +5,9 @@ import { Item, SuggestionBasedText } from "../../types";
 import QuantitySelector from "../QuantitySelector";
 import SuggestionBasedInput from "../SuggestionBasedInput";
 
-import brands from "custom/brands.json";
-
 import styles from "standard.scss";
 import { useCategoriesJson } from "features/firebase/categories/CategoriesProvider";
+import { useBrands } from "features/firebase/brands/BrandsProvider";
 
 type Props = {
   onCancelClick: () => void;
@@ -89,13 +88,16 @@ export default function AddNewItem({
   const [category, setCategory] = useState<SuggestionBasedText>(
     initialItem?.category || { label: null, id: null }
   );
-  const [brand, setBrand] = useState<string>(initialItem?.brand || "");
+  const [brand, setBrand] = useState<SuggestionBasedText>(
+    initialItem?.brand || { label: null, id: null }
+  );
 
   const styles = useStyles();
 
   const itemButtonIsDisabled = !(quantity && category && category.label);
 
   const categories = useCategoriesJson();
+  const brands = useBrands();
 
   return (
     <div className={styles.wrapper}>
@@ -114,10 +116,8 @@ export default function AddNewItem({
           inputPrompt={
             'Search for the litter brand e.g. "Coca Cola" or "Cadbury"'
           }
-          callback={(suggestion: SuggestionBasedText) =>
-            setBrand(suggestion?.label || "")
-          }
-          initialLabel={initialItem?.brand}
+          callback={setBrand}
+          initialLabel={initialItem?.brand?.label || ""}
           className={styles.brand}
         />
       </div>

--- a/src/pages/photo/components/ItemOverview/ItemOverview.tsx
+++ b/src/pages/photo/components/ItemOverview/ItemOverview.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme) => ({
 export default function ItemOverview({
   quantity,
   brand,
-  type: { label },
+  category: { label },
   handleRemove,
   handleClick
 }: Props) {

--- a/src/pages/photo/components/ItemOverview/ItemOverview.tsx
+++ b/src/pages/photo/components/ItemOverview/ItemOverview.tsx
@@ -34,8 +34,8 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ItemOverview({
   quantity,
-  brand,
-  category: { label },
+  brand: { label: brandLabel },
+  category: { label: categoryLabel },
   handleRemove,
   handleClick
 }: Props) {
@@ -44,7 +44,7 @@ export default function ItemOverview({
 
   return (
     <div className={styles.wrapper} onClick={handleClick}>
-      {quantity} {brand} {label}
+      {quantity} {brandLabel} {categoryLabel}
       <CloseIcon
         className={styles.cross}
         onClick={(e) => {

--- a/src/pages/photo/components/ItemOverviewList/ItemOverviewList.tsx
+++ b/src/pages/photo/components/ItemOverviewList/ItemOverviewList.tsx
@@ -22,7 +22,7 @@ export default function ItemOverviewList({
             {...item}
             handleRemove={() => handleRemoveItem(index)}
             handleClick={() => handleItemClick(index)}
-            key={`${item.type.label}-${item.quantity}`}
+            key={`${item.category.label}-${item.quantity}`}
           />
         );
       })}

--- a/src/pages/photo/components/SuggestionBasedInput/utils.ts
+++ b/src/pages/photo/components/SuggestionBasedInput/utils.ts
@@ -1,29 +1,36 @@
 import _ from "lodash";
 
-type Suggestion = { key: string; label: string; synonyms?: string[] };
-type SuggestionArr = Array<Suggestion>;
+export type SuggestionT = {
+  label: string;
+  synonyms: string[];
+  id: string;
+};
+type SuggestionArr = Array<SuggestionT>;
 
 export function getSortedSuggestions(sourceData: Object): SuggestionArr {
   return _.sortBy(
-    Object.keys(sourceData).map((key) => {
+    Object.keys(sourceData).map((id) => {
+      // @ts-ignore
+      const { label, synonyms = [] } = sourceData[id];
+
       return {
-        key,
-        //@ts-ignore
-        label: sourceData[key].label,
-        //@ts-ignore
-        synonyms: sourceData[key].synonyms
+        label,
+        synonyms,
+        id
       };
-    }),
-    ({ label }) => label
+    })
   );
 }
 
-export function getSuggestionsMatchingInput(sortedSuggestions: SuggestionArr, input: string): SuggestionArr {
+export function getSuggestionsMatchingInput(
+  sortedSuggestions: SuggestionArr,
+  input: string
+): SuggestionArr {
   return sortedSuggestions.filter(filterCat(input));
 }
 
-function filterCat(input: string): (category: Suggestion) => boolean {
-  return function (category: Suggestion) {
+function filterCat(input: string): (category: SuggestionT) => boolean {
+  return function (category: SuggestionT) {
     if (input.length === 0) {
       return false;
     }
@@ -33,13 +40,16 @@ function filterCat(input: string): (category: Suggestion) => boolean {
       .concat(synonyms || [])
       .map((x) => x.toLowerCase());
 
-    return normalisedCategories
-      .map(category => category.includes(normalisedInput))
-      .includes(true);
+    return normalisedCategories.some((category) =>
+      category.includes(normalisedInput)
+    );
   };
 }
 
-export function getLeafKey(sourceData: object, input: string): string | null {
+export function getSuggestionId(
+  sourceData: object,
+  input: string
+): string | null {
   if (input.length === 0) {
     return "none";
   }
@@ -50,7 +60,7 @@ export function getLeafKey(sourceData: object, input: string): string | null {
   );
 
   if (category) {
-    return category.key;
+    return category.id;
   }
 
   return null;

--- a/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
+++ b/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
@@ -96,7 +96,8 @@ async function sendFile({
     ({ quantity, category, brand, barcode }) => {
       totalCount = totalCount + quantity;
       return {
-        brand,
+        brand: brand.label,
+        brandId: brand.id,
         barcode: barcode || null,
         number: quantity,
         label: category.label,

--- a/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
+++ b/src/pages/photo/components/UploadPhotoDialog/useSendFile.ts
@@ -92,16 +92,20 @@ async function sendFile({
   gtagEvent("Upload", "Photo");
 
   let totalCount: number = 0;
-  const transformedItems = items.map(({ quantity, type, brand, barcode }) => {
-    totalCount = totalCount + quantity;
-    return {
-      brand,
-      barcode: barcode || null,
-      number: quantity,
-      leafkey: type && type.leafKey,
-      label: type && type.label
-    };
-  });
+  const transformedItems = items.map(
+    ({ quantity, category, brand, barcode }) => {
+      totalCount = totalCount + quantity;
+      return {
+        brand,
+        barcode: barcode || null,
+        number: quantity,
+        label: category.label,
+        categoryId: category.id,
+        // legacy
+        leafkey: category.id
+      };
+    }
+  );
 
   const dataToSend = {
     ...imgLocation,

--- a/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
+++ b/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
@@ -190,7 +190,7 @@ export function CategoriseLitterPageWithFileInfo() {
                     if (isProductInfo(result)) {
                       addNewItem({
                         quantity: 1,
-                        brand: result.brand,
+                        brand: { label: result.brand, id: FROM_BARCODE_ID },
                         category: {
                           id: FROM_BARCODE_ID,
                           label: result.productName

--- a/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
+++ b/src/pages/photo/pages/CategorisePhotoPage/CategorisePhotoPage.tsx
@@ -34,6 +34,8 @@ import BarcodeScanner, {
   isProductInfo
 } from "pages/photo/components/BarcodeScanner";
 
+const FROM_BARCODE_ID = "from-barcode-scanner";
+
 const useStyles = makeStyles((theme) => ({
   wrapper: {
     display: "flex",
@@ -189,7 +191,10 @@ export function CategoriseLitterPageWithFileInfo() {
                       addNewItem({
                         quantity: 1,
                         brand: result.brand,
-                        type: { label: result.productName, leafKey: null },
+                        category: {
+                          id: FROM_BARCODE_ID,
+                          label: result.productName
+                        },
                         barcode: result.barcode
                       });
                     } else {

--- a/src/pages/photo/types/index.ts
+++ b/src/pages/photo/types/index.ts
@@ -1,11 +1,11 @@
 export type SuggestionBasedText = {
-  leafKey: string | null;
   label: string | null;
+  id: string | null;
 };
 
 export type Item = {
   quantity: number;
-  type: SuggestionBasedText;
+  category: SuggestionBasedText;
   brand: string;
   barcode?: number;
 };

--- a/src/pages/photo/types/index.ts
+++ b/src/pages/photo/types/index.ts
@@ -6,6 +6,6 @@ export type SuggestionBasedText = {
 export type Item = {
   quantity: number;
   category: SuggestionBasedText;
-  brand: string;
+  brand: SuggestionBasedText;
   barcode?: number;
 };

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -154,9 +154,9 @@ export function Routes({
         <FeedbackRoute user={user} />
       </ModeratorRoute>
 
-      <Route path={linkToAdminPages()}>
+      <ModeratorRoute path={linkToAdminPages()} user={user}>
         <AdminRouter />
-      </Route>
+      </ModeratorRoute>
 
       <Route path={linkToPhotoPage()}>
         <PhotoRoute />

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -154,9 +154,9 @@ export function Routes({
         <FeedbackRoute user={user} />
       </ModeratorRoute>
 
-      <ModeratorRoute path={linkToAdminPages()} user={user}>
+      <Route path={linkToAdminPages()}>
         <AdminRouter />
-      </ModeratorRoute>
+      </Route>
 
       <Route path={linkToPhotoPage()}>
         <PhotoRoute />

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -40,6 +40,8 @@ import { linkToAccountPage } from "./account/links";
 import { useStats } from "providers/StatsProvider";
 import { linkToMissionsPage } from "./missions/links";
 import MissionsRoute from "./missions/Route";
+import linkToAdminPages from "./admin/links";
+import AdminRouter from "./admin/Router";
 
 type Props = {
   user: User;
@@ -151,6 +153,10 @@ export function Routes({
       <ModeratorRoute path={linkToFeedbackReports()} user={user}>
         <FeedbackRoute user={user} />
       </ModeratorRoute>
+
+      <Route path={linkToAdminPages()}>
+        <AdminRouter />
+      </Route>
 
       <Route path={linkToPhotoPage()}>
         <PhotoRoute />

--- a/src/routes/admin/Router.tsx
+++ b/src/routes/admin/Router.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
+import linkToBrands from "./brands/link";
+import BrandsRoute from "./brands/Route";
 import linkToCategories from "./categories/link";
 import CategoriesRoute from "./categories/Route";
 
@@ -8,6 +10,9 @@ export default function AdminRouter() {
     <Switch>
       <Route path={linkToCategories()}>
         <CategoriesRoute />
+      </Route>
+      <Route path={linkToBrands()}>
+        <BrandsRoute />
       </Route>
 
       <Redirect to={"/"} />

--- a/src/routes/admin/Router.tsx
+++ b/src/routes/admin/Router.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Switch, Route, Redirect } from "react-router-dom";
+import linkToCategories from "./categories/link";
+import CategoriesRoute from "./categories/Route";
+
+export default function AdminRouter() {
+  return (
+    <Switch>
+      <Route path={linkToCategories()}>
+        <CategoriesRoute />
+      </Route>
+
+      <Redirect to={"/"} />
+    </Switch>
+  );
+}

--- a/src/routes/admin/brands/Route.tsx
+++ b/src/routes/admin/brands/Route.tsx
@@ -1,0 +1,11 @@
+import PageWrapper from "components/PageWrapper";
+import BrandsManagementPage from "pages/admin/brands/Brands";
+import React from "react";
+
+export default function BrandsRoute() {
+  return (
+    <PageWrapper label="Brands" navigationHandler={{ handleBack: () => {} }}>
+      <BrandsManagementPage />
+    </PageWrapper>
+  );
+}

--- a/src/routes/admin/brands/Route.tsx
+++ b/src/routes/admin/brands/Route.tsx
@@ -1,10 +1,15 @@
 import PageWrapper from "components/PageWrapper";
 import BrandsManagementPage from "pages/admin/brands/Brands";
 import React from "react";
+import { useHistory } from "react-router";
 
 export default function BrandsRoute() {
+  const history = useHistory();
   return (
-    <PageWrapper label="Brands" navigationHandler={{ handleBack: () => {} }}>
+    <PageWrapper
+      label="Brands"
+      navigationHandler={{ handleBack: () => history.push("/") }}
+    >
       <BrandsManagementPage />
     </PageWrapper>
   );

--- a/src/routes/admin/brands/link.ts
+++ b/src/routes/admin/brands/link.ts
@@ -1,0 +1,5 @@
+import linkToAdminPages from "../links";
+
+export default function linkToBrands() {
+  return `${linkToAdminPages()}/brands`;
+}

--- a/src/routes/admin/categories/Route.tsx
+++ b/src/routes/admin/categories/Route.tsx
@@ -1,12 +1,14 @@
 import PageWrapper from "components/PageWrapper";
 import CategoriesManagementPage from "pages/admin/categories/Categories";
 import React from "react";
+import { useHistory } from "react-router";
 
 export default function CategoriesRoute() {
+  const history = useHistory();
   return (
     <PageWrapper
       label="Categories"
-      navigationHandler={{ handleBack: () => {} }}
+      navigationHandler={{ handleBack: () => history.push("/") }}
     >
       <CategoriesManagementPage />
     </PageWrapper>

--- a/src/routes/admin/categories/Route.tsx
+++ b/src/routes/admin/categories/Route.tsx
@@ -1,0 +1,14 @@
+import PageWrapper from "components/PageWrapper";
+import CategoriesManagementPage from "pages/admin/categories/Categories";
+import React from "react";
+
+export default function CategoriesRoute() {
+  return (
+    <PageWrapper
+      label="Categories"
+      navigationHandler={{ handleBack: () => {} }}
+    >
+      <CategoriesManagementPage />
+    </PageWrapper>
+  );
+}

--- a/src/routes/admin/categories/link.ts
+++ b/src/routes/admin/categories/link.ts
@@ -1,0 +1,5 @@
+import linkToAdminPages from "../links";
+
+export default function linkToCategories() {
+  return `${linkToAdminPages()}/categories`;
+}

--- a/src/routes/admin/links.ts
+++ b/src/routes/admin/links.ts
@@ -1,0 +1,3 @@
+export default function linkToAdminPages() {
+  return "/admin";
+}

--- a/src/routes/components/ModeratorRoute.tsx
+++ b/src/routes/components/ModeratorRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, useHistory } from "react-router-dom";
+import { Route } from "react-router-dom";
 
 import User from "types/User";
 
@@ -11,11 +11,5 @@ type Props = {
 
 export default function ModeratorRoute({ user, children, path }: Props) {
   const isModerator = user && user.isModerator;
-  const history = useHistory();
-
-  if (user && !user.isModerator) {
-    history.replace("/");
-  }
-
   return isModerator ? <Route path={path}>{children}</Route> : null;
 }

--- a/src/routes/components/ModeratorRoute.tsx
+++ b/src/routes/components/ModeratorRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route } from "react-router-dom";
+import { Route, useHistory } from "react-router-dom";
 
 import User from "types/User";
 
@@ -11,5 +11,11 @@ type Props = {
 
 export default function ModeratorRoute({ user, children, path }: Props) {
   const isModerator = user && user.isModerator;
+  const history = useHistory();
+
+  if (user && !user.isModerator) {
+    history.replace("/");
+  }
+
   return isModerator ? <Route path={path}>{children}</Route> : null;
 }

--- a/src/routes/photo/Route.tsx
+++ b/src/routes/photo/Route.tsx
@@ -3,9 +3,12 @@ import { useHistory, useLocation } from "react-router";
 
 import PageWrapper from "components/PageWrapper";
 import PhotoPageStateProvider from "pages/photo/state";
+
+import CategoriesProvider from "features/firebase/categories/CategoriesProvider";
+import BrandsProvider from "features/firebase/brands/BrandsProvider";
+
 import PhotoPageSubRouter from "./routes/SubRouter";
 import { linkToNewPhoto } from "./routes/new/links";
-import CategoriesProvider from "features/firebase/categories/CategoriesProvider";
 
 export default function PhotoRoute() {
   const history = useHistory();
@@ -19,12 +22,14 @@ export default function PhotoRoute() {
   return (
     <PhotoPageStateProvider>
       <CategoriesProvider>
-        <PageWrapper
-          label={"Record your litter"}
-          navigationHandler={navigationHandler}
-        >
-          <PhotoPageSubRouter />
-        </PageWrapper>
+        <BrandsProvider>
+          <PageWrapper
+            label={"Record your litter"}
+            navigationHandler={navigationHandler}
+          >
+            <PhotoPageSubRouter />
+          </PageWrapper>
+        </BrandsProvider>
       </CategoriesProvider>
     </PhotoPageStateProvider>
   );

--- a/src/routes/photo/Route.tsx
+++ b/src/routes/photo/Route.tsx
@@ -5,6 +5,7 @@ import PageWrapper from "components/PageWrapper";
 import PhotoPageStateProvider from "pages/photo/state";
 import PhotoPageSubRouter from "./routes/SubRouter";
 import { linkToNewPhoto } from "./routes/new/links";
+import CategoriesProvider from "features/firebase/categories/CategoriesProvider";
 
 export default function PhotoRoute() {
   const history = useHistory();
@@ -17,12 +18,14 @@ export default function PhotoRoute() {
 
   return (
     <PhotoPageStateProvider>
-      <PageWrapper
-        label={"Record your litter"}
-        navigationHandler={navigationHandler}
-      >
-        <PhotoPageSubRouter />
-      </PageWrapper>
+      <CategoriesProvider>
+        <PageWrapper
+          label={"Record your litter"}
+          navigationHandler={navigationHandler}
+        >
+          <PhotoPageSubRouter />
+        </PageWrapper>
+      </CategoriesProvider>
     </PhotoPageStateProvider>
   );
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,103 +1,18 @@
-service cloud.firestore {
-  match /databases/{database}/documents {
-
-    function isAdmin() {
-    	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true
-    }
-
-    function isModerator() {
-    	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true
-    }
-
-    function isUser(uid) {
-    	return request.auth.uid == uid
-    }
-
-    function isPublished() {
-    	return resource.data.published == true
-    }
-
-    // anybody can read the photos but only admin can write
-    match /photos/{photoId} {
-      // allow read: if request.auth.uid != null;
-      // allow read: if isModerator() || isAdmin() || resource.data.moderated != null;
-      allow read: if isPublished() || isModerator()
-
-      // allow create: if request.auth.uid != null;
-			allow create: if true;
-
-      allow update: if isModerator();
-
-      // allow update: if resource.data.owner_id == request.auth.uid && resource.data.moderated=null
-
-      allow write: if isAdmin();
-    }
-
-    // anybody can create a feedback but only login user can update
-    // only moderator or admin can read and update the feedback
-    match /feedbacks/{feedback} {
-
-      allow create: if true;
-
-      allow read: if isModerator() || isAdmin();
-      allow update: if isModerator() || isAdmin();
-
-      //allow update: if resource.data.owner_id == request.auth.uid
-
-      // allow delete: if isModerator() || isAdmin();
-    }
-
-    // data written by admin
-    match /users/{uid} {
-    	allow read: if isAdmin() || isUser(uid);
-      // Temporarily making true to enable mission owners to add pending users to missions.
-      allow write: if isAdmin() || isUser(uid) || true;
-    }
-
-    // Collection with system data. The Doc stats contains statistics.
-    match /sys/stats {
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
       allow read: if true;
     }
 
-    // some extra config
-    match /sys/config {
-      allow read: if true;
-    }
-    
-    // data written by admin
-    match /missions/{missionId} {
-    
-      function isMissionOwner() {
-        return get(/databases/$(database)/documents/missions/$(missionId)).data.ownerUserId == request.auth.uid;
-      }	
-      
-      function isPrivateMission() {
-        return get(/databases/$(database)/documents/missions/$(missionId)).data.isPrivate == true;
-      }	
-    
-      allow create: if true;
-    	allow read: if true;
-      // Workaround as true because people need to be able to add themselvse to public missions
-      // and add themselves as pending members to private missions.
-      allow write: if true;
-    }
-    
-    match /categories {
-    	allow read: if true
-    }
-    
-    match /categories/{categoryId} {
-    	allow read: if true
-      allow write: if isModerator() || isAdmin();
-    }
-    
-    match /brands {
-    	allow read: if true
-    }
-    
-    match /brands/{brandId} {
-    	allow read: if true
-      allow write: if isModerator() || isAdmin();
+    match /photos {
+    	match /{photoId} {
+      	match /original.jpg {
+        	allow write: if resource == null
+                        && request.auth != null 
+          							&& request.resource.size < 2 * 1024 * 1024
+                    		&& request.resource.contentType.matches('image/.*')
+        }
+      }
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,18 +1,103 @@
-service firebase.storage {
-  match /b/{bucket}/o {
-    match /{allPaths=**} {
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAdmin() {
+    	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true
+    }
+
+    function isModerator() {
+    	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true
+    }
+
+    function isUser(uid) {
+    	return request.auth.uid == uid
+    }
+
+    function isPublished() {
+    	return resource.data.published == true
+    }
+
+    // anybody can read the photos but only admin can write
+    match /photos/{photoId} {
+      // allow read: if request.auth.uid != null;
+      // allow read: if isModerator() || isAdmin() || resource.data.moderated != null;
+      allow read: if isPublished() || isModerator()
+
+      // allow create: if request.auth.uid != null;
+			allow create: if true;
+
+      allow update: if isModerator();
+
+      // allow update: if resource.data.owner_id == request.auth.uid && resource.data.moderated=null
+
+      allow write: if isAdmin();
+    }
+
+    // anybody can create a feedback but only login user can update
+    // only moderator or admin can read and update the feedback
+    match /feedbacks/{feedback} {
+
+      allow create: if true;
+
+      allow read: if isModerator() || isAdmin();
+      allow update: if isModerator() || isAdmin();
+
+      //allow update: if resource.data.owner_id == request.auth.uid
+
+      // allow delete: if isModerator() || isAdmin();
+    }
+
+    // data written by admin
+    match /users/{uid} {
+    	allow read: if isAdmin() || isUser(uid);
+      // Temporarily making true to enable mission owners to add pending users to missions.
+      allow write: if isAdmin() || isUser(uid) || true;
+    }
+
+    // Collection with system data. The Doc stats contains statistics.
+    match /sys/stats {
       allow read: if true;
     }
 
-    match /photos {
-    	match /{photoId} {
-      	match /original.jpg {
-        	allow write: if resource == null
-                        && request.auth != null 
-          							&& request.resource.size < 2 * 1024 * 1024
-                    		&& request.resource.contentType.matches('image/.*')
-        }
-      }
+    // some extra config
+    match /sys/config {
+      allow read: if true;
+    }
+    
+    // data written by admin
+    match /missions/{missionId} {
+    
+      function isMissionOwner() {
+        return get(/databases/$(database)/documents/missions/$(missionId)).data.ownerUserId == request.auth.uid;
+      }	
+      
+      function isPrivateMission() {
+        return get(/databases/$(database)/documents/missions/$(missionId)).data.isPrivate == true;
+      }	
+    
+      allow create: if true;
+    	allow read: if true;
+      // Workaround as true because people need to be able to add themselvse to public missions
+      // and add themselves as pending members to private missions.
+      allow write: if true;
+    }
+    
+    match /categories {
+    	allow read: if true
+    }
+    
+    match /categories/{categoryId} {
+    	allow read: if true
+      allow write: if isModerator() || isAdmin();
+    }
+    
+    match /brands {
+    	allow read: if true
+    }
+    
+    match /brands/{brandId} {
+    	allow read: if true
+      allow write: if isModerator() || isAdmin();
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "baseUrl": "src",
-    "typeRoots": ["./types", "./node_modules/@types"],
-    "isolatedModules": true
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["src", ".storybook/*"]
 }


### PR DESCRIPTION
A lot of it is duplicated so it's not as bad as it looks!

The intention of this is to solve having to release new app versions for things like https://github.com/PlasticPatrol/PlasticPatrolWeb/issues/219 by allowing moderators to make changes
In terms of just managing stuff, probably a little overkill, but this should make data analysis in the future much easier with more stable ids etc

I haven't even bothered trying to make the new pages fit on mobile - I think it'll be ok to just provide this functionality for desktop users

I'm not super familiar with how the firebase caching works - so it may make sense for not to provide a fallback of the hardcoded jsons still

This may have introduced some performance issues with the initial brand filtering - I'll have a play and see if I can sort