### PR TITLE
Fix blank names with Apple Sign-In

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -10,6 +10,7 @@ def capacitor_pods
   # Automatic Capacitor Pod dependencies, do not delete
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+  pod 'CapacitorCommunityAppleSignIn', :path => '../../node_modules/@capacitor-community/apple-sign-in'
   pod 'CapacitorCommunityFirebaseCrashlytics', :path => '../../node_modules/@capacitor-community/firebase-crashlytics'
   pod 'CapacitorFirebaseAuth', :path => '../../node_modules/capacitor-firebase-auth'
   pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "public": true,
   "homepage": "./",
   "dependencies": {
+    "@capacitor-community/apple-sign-in": "^1.0.0",
     "@capacitor-community/firebase-crashlytics": "^0.4.0",
     "@capacitor/android": "2.4.7",
     "@capacitor/cli": "^2.4.7",
@@ -45,6 +46,7 @@
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.5",
     "rxjs": "^6.5.5",
+    "scriptjs": "^2.5.9",
     "ts-loader": "^8.0.17",
     "ts-node": "^9.1.1",
     "web-vitals": "^1.1.0",

--- a/src/components/LoginFirebase.js
+++ b/src/components/LoginFirebase.js
@@ -16,6 +16,12 @@ import appleIcon from "../assets/images/apple.svg";
 import { createButton } from "react-social-login-buttons";
 import { cfaSignIn } from "capacitor-firebase-auth/alternative";
 
+import {
+  SignInWithAppleResponse,
+  SignInWithAppleOptions
+} from "@capacitor-community/apple-sign-in";
+import { Plugins } from "@capacitor/core";
+
 const FacebookLoginButton = createButton({
   text: "Sign in with Facebook",
   icon: () => <img src={facebookIcon} alt="email" />,
@@ -63,19 +69,47 @@ const LoginFirebase = (props) => {
     }
   };
 
-  const signInMobile = (provider) => {
-    cfaSignIn(provider).subscribe(
-      ({
-        userCredential
-      }: {
-        userCredential: firebase.auth.UserCredential
-      }) => {
-        if (userCredential.additionalUserInfo.isNewUser) {
-          sendEmailVerification();
+  const signInMobile = async (provider) => {
+    if (provider === "apple.com") {
+      let options: SignInWithAppleOptions = {
+        clientId: "app.plasticpatrol.co.uk",
+        redirectURI: "/",
+        scopes: "email name"
+      };
+
+      try {
+        const result: SignInWithAppleResponse = await Plugins.SignInWithApple.authorize(options);
+        const { identityToken, givenName, familyName } = result.response;
+        // Apple sign-in only provides full response during the first successful sign in!!!
+        // After that, familyName, givenName and email fields will be null.
+        // We save to local storage for onAuthStateChanged in order to set the correct displayName to user.
+        const displayName = givenName && familyName ? `${givenName} ${familyName}` : givenName ? givenName : familyName;
+        if (displayName) {
+          localStorage.setItem("displayName", displayName);
+        }
+        const credential = await new firebase.auth.OAuthProvider("apple.com").credential(identityToken);
+        const authResult = await firebase.auth().signInWithCredential(credential);
+        if (displayName) {
+          await authResult.user.updateProfile({ displayName: displayName });
         }
         handleClose();
+      } catch (error) {
+        console.log(error);
       }
-    );
+    } else {
+      cfaSignIn(provider).subscribe(
+        ({
+          userCredential
+        }: {
+          userCredential: firebase.auth.UserCredential
+        }) => {
+          if (userCredential.additionalUserInfo.isNewUser) {
+            sendEmailVerification();
+          }
+          handleClose();
+        }
+      );
+    }
   };
 
   return (

--- a/src/features/firebase/authFirebase.ts
+++ b/src/features/firebase/authFirebase.ts
@@ -61,7 +61,7 @@ export const onAuthStateChanged = ({ onSignOut, setUser }: Args) => {
       };
 
       enableOrDisableFeatures(currentUser);
-    } catch {}
+    } catch { }
 
     // creates a new object ref so react updates
     console.log(

--- a/src/features/firebase/authFirebase.ts
+++ b/src/features/firebase/authFirebase.ts
@@ -36,9 +36,10 @@ export const onAuthStateChanged = ({ onSignOut, setUser }: Args) => {
     gtagSetId(user?.uid);
     gtagEvent("Logged in", "User", user?.uid);
 
+    const displayName = localStorage.getItem("displayName"); // apple login the first time missing names workaround
     let currentUser = new User(
       user.uid,
-      user.displayName || "",
+      displayName ? displayName : user.displayName || "",
       false,
       false,
       user.email || "",

--- a/src/features/firebase/authFirebase.ts
+++ b/src/features/firebase/authFirebase.ts
@@ -7,13 +7,6 @@ import dbFirebase from "./dbFirebase";
 import { enableOrDisableFeatures } from "custom/featuresFlags";
 import { addGravatarInfo } from "utils/gravatar";
 
-const getProvider = (user: any) => {
-  if (user.providerData.length > 0) {
-    return user.providerData[0].providerId;
-  }
-  return null;
-};
-
 type Args = {
   onSignOut: () => void;
   setUser: (user?: User) => void;
@@ -37,6 +30,8 @@ export const onAuthStateChanged = ({ onSignOut, setUser }: Args) => {
     gtagEvent("Logged in", "User", user?.uid);
 
     const displayName = localStorage.getItem("displayName"); // apple login the first time missing names workaround
+    const idTokenResult = await user.getIdTokenResult();
+
     let currentUser = new User(
       user.uid,
       displayName ? displayName : user.displayName || "",
@@ -49,7 +44,7 @@ export const onAuthStateChanged = ({ onSignOut, setUser }: Args) => {
       "",
       null,
       "",
-      getProvider(user),
+      idTokenResult.signInProvider,
       []
     );
 

--- a/storage.rules
+++ b/storage.rules
@@ -14,5 +14,13 @@ service firebase.storage {
         }
       }
     }
+
+    match /missions {
+      match /{missionId} {
+        match /{allPaths=**} {
+          allow write: if request.auth != null;
+        }
+      }
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,6 +1268,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@capacitor-community/apple-sign-in@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@capacitor-community/apple-sign-in/-/apple-sign-in-1.0.0.tgz#5166e0190da67bc82c770fee1e2020c029ab274a"
+  integrity sha512-31FGV2F/xI3N8g6YgCFpn/ydMwOVvbQjzbPAMraP55yMV+1/EbTU2RI0i7ixVDkDSU979CCSa2fZRbDBJDzlhw==
+  dependencies:
+    "@capacitor/core" latest
+
 "@capacitor-community/firebase-crashlytics@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@capacitor-community/firebase-crashlytics/-/firebase-crashlytics-0.4.0.tgz#a8486bad10b7f230bc4a73d5199a61c97dfffb5f"
@@ -18183,6 +18190,11 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+scriptjs@^2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
+  integrity sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
The `displayName` from the `capacitor-firebase-auth` plugin's apple sigin-in is always empty which is an open issue.

This PR is to change to use `@capacitor-community/apple-sign-in` plugin to get the user info correctly, and also update profile in firebase. However, the `updateProfile` doesn't trigger `onAuthStateChanged` so we save the `displayName` to local storage in order to set the correct name to currentUser.

Note that user information like `familyName`, `givenName` and `email` will only be retrievable with Apple Sign-in for **the very first time**. Subsequent attempts don't return the user status. [[Ref]](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple)

